### PR TITLE
Implement basic frontend controllers and views with Tailwind and contact form

### DIFF
--- a/app/Http/Controllers/Frontend/BlogController.php
+++ b/app/Http/Controllers/Frontend/BlogController.php
@@ -3,9 +3,15 @@
 namespace App\Http\Controllers\Frontend;
 
 use App\Http\Controllers\Controller;
-use Illuminate\Http\Request;
+use Illuminate\View\View;
 
 class BlogController extends Controller
 {
-    //
+    /**
+     * Display the blog index page.
+     */
+    public function index(): View
+    {
+        return view('frontend.blog');
+    }
 }

--- a/app/Http/Controllers/Frontend/ContactController.php
+++ b/app/Http/Controllers/Frontend/ContactController.php
@@ -3,9 +3,41 @@
 namespace App\Http\Controllers\Frontend;
 
 use App\Http\Controllers\Controller;
+use App\Models\Lead;
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
+use Illuminate\View\View;
 
 class ContactController extends Controller
 {
-    //
+    /**
+     * Show the contact form.
+     */
+    public function index(): View
+    {
+        return view('frontend.contact');
+    }
+
+    /**
+     * Store a new contact lead.
+     */
+    public function store(Request $request): RedirectResponse
+    {
+        $validated = $request->validate([
+            'name' => ['required', 'string', 'max:255'],
+            'email' => ['required', 'email'],
+            'phone' => ['nullable', 'string', 'max:255'],
+            'message' => ['required', 'string'],
+        ]);
+
+        Lead::create([
+            'name' => $validated['name'],
+            'email' => $validated['email'],
+            'phone' => $validated['phone'] ?? null,
+            'notes' => $validated['message'],
+            'source' => 'contact',
+        ]);
+
+        return back()->with('status', 'Thank you for contacting us!');
+    }
 }

--- a/app/Http/Controllers/Frontend/HomeController.php
+++ b/app/Http/Controllers/Frontend/HomeController.php
@@ -3,9 +3,15 @@
 namespace App\Http\Controllers\Frontend;
 
 use App\Http\Controllers\Controller;
-use Illuminate\Http\Request;
+use Illuminate\View\View;
 
 class HomeController extends Controller
 {
-    //
+    /**
+     * Show the application home page.
+     */
+    public function index(): View
+    {
+        return view('frontend.home');
+    }
 }

--- a/app/Http/Controllers/Frontend/ProductController.php
+++ b/app/Http/Controllers/Frontend/ProductController.php
@@ -3,9 +3,15 @@
 namespace App\Http\Controllers\Frontend;
 
 use App\Http\Controllers\Controller;
-use Illuminate\Http\Request;
+use Illuminate\View\View;
 
 class ProductController extends Controller
 {
-    //
+    /**
+     * Display a listing of products.
+     */
+    public function index(): View
+    {
+        return view('frontend.products');
+    }
 }

--- a/app/Http/Controllers/Frontend/ServiceController.php
+++ b/app/Http/Controllers/Frontend/ServiceController.php
@@ -3,9 +3,15 @@
 namespace App\Http\Controllers\Frontend;
 
 use App\Http\Controllers\Controller;
-use Illuminate\Http\Request;
+use Illuminate\View\View;
 
 class ServiceController extends Controller
 {
-    //
+    /**
+     * Display the services page.
+     */
+    public function index(): View
+    {
+        return view('frontend.services');
+    }
 }

--- a/app/Models/Lead.php
+++ b/app/Models/Lead.php
@@ -6,5 +6,21 @@ use Illuminate\Database\Eloquent\Model;
 
 class Lead extends Model
 {
-    //
+    /**
+     * The attributes that are mass assignable.
+     */
+    protected $fillable = [
+        'name',
+        'email',
+        'phone',
+        'company',
+        'source',
+        'notes',
+        'pipeline_stage_id',
+        'budget_min',
+        'budget_max',
+        'timeline',
+        'tech_stack',
+        'assigned_to_id',
+    ];
 }

--- a/resources/views/frontend/blog.blade.php
+++ b/resources/views/frontend/blog.blade.php
@@ -1,0 +1,6 @@
+@extends('layouts.frontend')
+
+@section('content')
+<h1 class="text-3xl font-bold mb-6">Blog</h1>
+<p class="text-gray-700">Latest posts coming soon.</p>
+@endsection

--- a/resources/views/frontend/contact.blade.php
+++ b/resources/views/frontend/contact.blade.php
@@ -1,0 +1,29 @@
+@extends('layouts.frontend')
+
+@section('content')
+<h1 class="text-3xl font-bold mb-6">Contact Us</h1>
+<form method="POST" action="{{ route('contact.store') }}" class="max-w-lg">
+    @csrf
+    <div class="mb-4">
+        <label class="block text-sm font-medium mb-1" for="name">Name</label>
+        <input class="w-full border-gray-300 rounded" name="name" id="name" value="{{ old('name') }}" required>
+        @error('name')<p class="text-red-600 text-sm mt-1">{{ $message }}</p>@enderror
+    </div>
+    <div class="mb-4">
+        <label class="block text-sm font-medium mb-1" for="email">Email</label>
+        <input type="email" class="w-full border-gray-300 rounded" name="email" id="email" value="{{ old('email') }}" required>
+        @error('email')<p class="text-red-600 text-sm mt-1">{{ $message }}</p>@enderror
+    </div>
+    <div class="mb-4">
+        <label class="block text-sm font-medium mb-1" for="phone">Phone</label>
+        <input class="w-full border-gray-300 rounded" name="phone" id="phone" value="{{ old('phone') }}">
+        @error('phone')<p class="text-red-600 text-sm mt-1">{{ $message }}</p>@enderror
+    </div>
+    <div class="mb-4">
+        <label class="block text-sm font-medium mb-1" for="message">Message</label>
+        <textarea class="w-full border-gray-300 rounded" name="message" id="message" rows="5" required>{{ old('message') }}</textarea>
+        @error('message')<p class="text-red-600 text-sm mt-1">{{ $message }}</p>@enderror
+    </div>
+    <button class="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700" type="submit">Send</button>
+</form>
+@endsection

--- a/resources/views/frontend/home.blade.php
+++ b/resources/views/frontend/home.blade.php
@@ -1,0 +1,8 @@
+@extends('layouts.frontend')
+
+@section('content')
+<div class="text-center">
+    <h1 class="text-4xl font-bold mb-4">Welcome to PerfexDev360</h1>
+    <p class="text-lg text-gray-700">Building ERP & customization services.</p>
+</div>
+@endsection

--- a/resources/views/frontend/products.blade.php
+++ b/resources/views/frontend/products.blade.php
@@ -1,0 +1,6 @@
+@extends('layouts.frontend')
+
+@section('content')
+<h1 class="text-3xl font-bold mb-6">Our Products</h1>
+<p class="text-gray-700">List of products coming soon.</p>
+@endsection

--- a/resources/views/frontend/services.blade.php
+++ b/resources/views/frontend/services.blade.php
@@ -1,0 +1,6 @@
+@extends('layouts.frontend')
+
+@section('content')
+<h1 class="text-3xl font-bold mb-6">Our Services</h1>
+<p class="text-gray-700">Details about services offered.</p>
+@endsection

--- a/resources/views/layouts/frontend.blade.php
+++ b/resources/views/layouts/frontend.blade.php
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{{ config('app.name', 'PerfexDev360') }}</title>
+    @vite(['resources/css/app.css', 'resources/js/app.js'])
+</head>
+<body class="antialiased text-gray-800">
+    <nav class="bg-white border-b">
+        <div class="container mx-auto px-4 py-4 flex justify-between">
+            <a href="{{ route('home') }}" class="font-bold">{{ config('app.name', 'PerfexDev360') }}</a>
+            <div class="space-x-4">
+                <a href="{{ route('products.index') }}" class="text-gray-600 hover:text-gray-900">Products</a>
+                <a href="{{ route('services.index') }}" class="text-gray-600 hover:text-gray-900">Services</a>
+                <a href="{{ route('blog.index') }}" class="text-gray-600 hover:text-gray-900">Blog</a>
+                <a href="{{ route('contact.index') }}" class="text-gray-600 hover:text-gray-900">Contact</a>
+            </div>
+        </div>
+    </nav>
+    <main class="container mx-auto px-4 py-8">
+        @if(session('status'))
+            <div class="mb-4 p-4 bg-green-100 text-green-700 rounded">
+                {{ session('status') }}
+            </div>
+        @endif
+        @yield('content')
+    </main>
+</body>
+</html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,7 +1,15 @@
 <?php
 
 use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\Frontend\BlogController;
+use App\Http\Controllers\Frontend\ContactController;
+use App\Http\Controllers\Frontend\HomeController;
+use App\Http\Controllers\Frontend\ProductController;
+use App\Http\Controllers\Frontend\ServiceController;
 
-Route::get('/', function () {
-    return view('welcome');
-});
+Route::get('/', [HomeController::class, 'index'])->name('home');
+Route::get('/products', [ProductController::class, 'index'])->name('products.index');
+Route::get('/services', [ServiceController::class, 'index'])->name('services.index');
+Route::get('/blog', [BlogController::class, 'index'])->name('blog.index');
+Route::get('/contact', [ContactController::class, 'index'])->name('contact.index');
+Route::post('/contact', [ContactController::class, 'store'])->name('contact.store');


### PR DESCRIPTION
## Summary
- Add frontend controllers for home, products, services, blog and contact pages
- Create Tailwind-based layout and views for public pages
- Persist contact form submissions as leads and wire up routes

## Testing
- `composer install` *(fails: CONNECT tunnel failed, response 403)*
- `php artisan test` *(fails: vendor/autoload.php missing)*

------
https://chatgpt.com/codex/tasks/task_e_689dcc1f629c83329e5891b4d476b132