### PR TITLE
Add Stripe and PayPal webhook handlers

### DIFF
--- a/app/Http/Controllers/Webhook/PayPalWebhookController.php
+++ b/app/Http/Controllers/Webhook/PayPalWebhookController.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace App\Http\Controllers\Webhook;
+
+use App\Http\Controllers\Controller;
+use App\Models\Invoice;
+use App\Models\Order;
+use App\Models\Payment;
+use App\Models\User;
+use App\Notifications\InvoicePaid;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Notification;
+
+class PayPalWebhookController extends Controller
+{
+    /**
+     * Handle incoming PayPal webhook.
+     */
+    public function handle(Request $request)
+    {
+        if (! $this->verifySignature($request)) {
+            Log::warning('PayPal webhook signature verification failed.');
+
+            return response()->json(['status' => 'invalid signature'], 400);
+        }
+
+        $payload = json_decode($request->getContent(), true);
+        $invoiceId = data_get($payload, 'resource.invoice_id') ?? data_get($payload, 'resource.custom_id');
+        $txnId = data_get($payload, 'resource.id');
+        $amount = data_get($payload, 'resource.amount.value');
+        $currency = strtoupper(data_get($payload, 'resource.amount.currency_code') ?? data_get($payload, 'resource.amount.currency'));
+
+        if (! $invoiceId || ! $invoice = Invoice::find($invoiceId)) {
+            Log::warning('Invoice not found for PayPal webhook.', ['invoice_id' => $invoiceId]);
+
+            return response()->json(['status' => 'invoice not found'], 404);
+        }
+
+        $invoice->status = 'paid';
+        $invoice->save();
+
+        $payment = new Payment();
+        $payment->invoice_id = $invoice->id;
+        $payment->provider = 'paypal';
+        $payment->provider_txn_id = $txnId;
+        $payment->amount = $amount;
+        $payment->currency = $currency;
+        $payment->status = 'succeeded';
+        $payment->meta = json_encode($payload);
+        $payment->paid_at = now();
+        $payment->save();
+
+        $order = Order::find($invoice->order_id);
+        if ($order && $order->user_id) {
+            $user = User::find($order->user_id);
+            if ($user) {
+                Notification::send($user, new InvoicePaid($invoice));
+            }
+        }
+
+        Log::info('PayPal webhook processed.', ['invoice_id' => $invoice->id, 'txn' => $txnId]);
+
+        return response()->json(['status' => 'ok']);
+    }
+
+    /**
+     * Verify PayPal webhook signature.
+     */
+    protected function verifySignature(Request $request): bool
+    {
+        $secret = config('services.paypal.webhook_secret');
+        $signature = $request->header('PayPal-Transmission-Sig');
+
+        if (! $secret || ! $signature) {
+            return false;
+        }
+
+        $expected = hash_hmac('sha256', $request->getContent(), $secret);
+
+        return hash_equals($expected, $signature);
+    }
+}

--- a/app/Http/Controllers/Webhook/StripeWebhookController.php
+++ b/app/Http/Controllers/Webhook/StripeWebhookController.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace App\Http\Controllers\Webhook;
+
+use App\Http\Controllers\Controller;
+use App\Models\Invoice;
+use App\Models\Order;
+use App\Models\Payment;
+use App\Models\User;
+use App\Notifications\InvoicePaid;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Notification;
+
+class StripeWebhookController extends Controller
+{
+    /**
+     * Handle incoming Stripe webhook.
+     */
+    public function handle(Request $request)
+    {
+        if (! $this->verifySignature($request)) {
+            Log::warning('Stripe webhook signature verification failed.');
+
+            return response()->json(['status' => 'invalid signature'], 400);
+        }
+
+        $payload = json_decode($request->getContent(), true);
+        $invoiceId = data_get($payload, 'data.object.metadata.invoice_id');
+        $txnId = data_get($payload, 'data.object.id');
+        $amount = data_get($payload, 'data.object.amount_paid');
+        $currency = strtoupper(data_get($payload, 'data.object.currency'));
+
+        if (! $invoiceId || ! $invoice = Invoice::find($invoiceId)) {
+            Log::warning('Invoice not found for Stripe webhook.', ['invoice_id' => $invoiceId]);
+
+            return response()->json(['status' => 'invoice not found'], 404);
+        }
+
+        $invoice->status = 'paid';
+        $invoice->save();
+
+        $payment = new Payment();
+        $payment->invoice_id = $invoice->id;
+        $payment->provider = 'stripe';
+        $payment->provider_txn_id = $txnId;
+        $payment->amount = $amount ? $amount / 100 : 0;
+        $payment->currency = $currency;
+        $payment->status = 'succeeded';
+        $payment->meta = json_encode($payload);
+        $payment->paid_at = now();
+        $payment->save();
+
+        $order = Order::find($invoice->order_id);
+        if ($order && $order->user_id) {
+            $user = User::find($order->user_id);
+            if ($user) {
+                Notification::send($user, new InvoicePaid($invoice));
+            }
+        }
+
+        Log::info('Stripe webhook processed.', ['invoice_id' => $invoice->id, 'txn' => $txnId]);
+
+        return response()->json(['status' => 'ok']);
+    }
+
+    /**
+     * Verify Stripe webhook signature.
+     */
+    protected function verifySignature(Request $request): bool
+    {
+        $secret = config('services.stripe.webhook_secret');
+        $signature = $request->header('Stripe-Signature');
+
+        if (! $secret || ! $signature) {
+            return false;
+        }
+
+        $expected = hash_hmac('sha256', $request->getContent(), $secret);
+
+        return hash_equals($expected, $signature);
+    }
+}

--- a/app/Notifications/InvoicePaid.php
+++ b/app/Notifications/InvoicePaid.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Notifications;
+
+use App\Models\Invoice;
+use Illuminate\Bus\Queueable;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class InvoicePaid extends Notification
+{
+    use Queueable;
+
+    public function __construct(public Invoice $invoice)
+    {
+    }
+
+    public function via(object $notifiable): array
+    {
+        return ['mail'];
+    }
+
+    public function toMail(object $notifiable): MailMessage
+    {
+        return (new MailMessage)
+            ->subject('Invoice Paid')
+            ->line('Invoice #' . $this->invoice->number . ' has been paid.')
+            ->line('Thank you for your payment.');
+    }
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,7 +1,12 @@
 <?php
 
 use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\Webhook\StripeWebhookController;
+use App\Http\Controllers\Webhook\PayPalWebhookController;
 
 Route::get('/', function () {
     return view('welcome');
 });
+
+Route::post('/webhooks/stripe', [StripeWebhookController::class, 'handle']);
+Route::post('/webhooks/paypal', [PayPalWebhookController::class, 'handle']);

--- a/tests/Feature/PayPalWebhookTest.php
+++ b/tests/Feature/PayPalWebhookTest.php
@@ -1,0 +1,48 @@
+<?php
+
+use App\Models\User;
+use App\Models\Order;
+use App\Models\Invoice;
+use App\Notifications\InvoicePaid;
+use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Facades\Config;
+
+it('handles paypal invoice paid webhook', function () {
+    Config::set('services.paypal.webhook_secret', 'paypal_secret');
+    Notification::fake();
+
+    $user = User::factory()->create();
+
+    $order = Order::unguarded(fn () => Order::create([
+        'user_id' => $user->id,
+        'number' => 'ORD-200',
+        'currency' => 'USD',
+        'status' => 'pending',
+    ]));
+
+    $invoice = Invoice::unguarded(fn () => Invoice::create([
+        'order_id' => $order->id,
+        'number' => 'INV-200',
+        'currency' => 'USD',
+    ]));
+
+    $payload = [
+        'resource' => [
+            'id' => 'txn_2',
+            'amount' => [
+                'value' => '10.00',
+                'currency_code' => 'USD',
+            ],
+            'invoice_id' => $invoice->id,
+        ],
+    ];
+
+    $body = json_encode($payload);
+    $signature = hash_hmac('sha256', $body, 'paypal_secret');
+
+    $this->postJson('/webhooks/paypal', $payload, ['PayPal-Transmission-Sig' => $signature])
+        ->assertOk();
+
+    expect($invoice->fresh()->status)->toBe('paid');
+    Notification::assertSentTo($user, InvoicePaid::class);
+});

--- a/tests/Feature/StripeWebhookTest.php
+++ b/tests/Feature/StripeWebhookTest.php
@@ -1,0 +1,50 @@
+<?php
+
+use App\Models\User;
+use App\Models\Order;
+use App\Models\Invoice;
+use App\Notifications\InvoicePaid;
+use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Facades\Config;
+
+it('handles stripe invoice paid webhook', function () {
+    Config::set('services.stripe.webhook_secret', 'test_secret');
+    Notification::fake();
+
+    $user = User::factory()->create();
+
+    $order = Order::unguarded(fn () => Order::create([
+        'user_id' => $user->id,
+        'number' => 'ORD-100',
+        'currency' => 'USD',
+        'status' => 'pending',
+    ]));
+
+    $invoice = Invoice::unguarded(fn () => Invoice::create([
+        'order_id' => $order->id,
+        'number' => 'INV-100',
+        'currency' => 'USD',
+    ]));
+
+    $payload = [
+        'data' => [
+            'object' => [
+                'id' => 'txn_1',
+                'amount_paid' => 1000,
+                'currency' => 'usd',
+                'metadata' => [
+                    'invoice_id' => $invoice->id,
+                ],
+            ],
+        ],
+    ];
+
+    $body = json_encode($payload);
+    $signature = hash_hmac('sha256', $body, 'test_secret');
+
+    $this->postJson('/webhooks/stripe', $payload, ['Stripe-Signature' => $signature])
+        ->assertOk();
+
+    expect($invoice->fresh()->status)->toBe('paid');
+    Notification::assertSentTo($user, InvoicePaid::class);
+});


### PR DESCRIPTION
## Summary
- add Stripe webhook controller to verify signatures, update invoices, log, and notify users
- add PayPal webhook controller handling signature check, invoice update, logging and notifications
- register webhook routes and cover with feature tests

## Testing
- `php artisan test` *(fails: vendor/autoload.php not found)*
- `composer install` *(fails: requires GitHub token)*

------
https://chatgpt.com/codex/tasks/task_e_689dcc2052008332ba95544fcf53355f