### PR TITLE
Add admin, portal, and API route groups

### DIFF
--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Providers;
+
+use Illuminate\Foundation\Support\Providers\RouteServiceProvider as ServiceProvider;
+use Illuminate\Support\Facades\Route;
+
+class RouteServiceProvider extends ServiceProvider
+{
+    /**
+     * Define the routes for the application.
+     */
+    public function boot(): void
+    {
+        $this->routes(function () {
+            Route::middleware('web')
+                ->group(base_path('routes/web.php'));
+
+            Route::middleware(['web', 'auth:sanctum', 'verified', 'role:admin'])
+                ->prefix('admin')
+                ->name('admin.')
+                ->group(base_path('routes/admin.php'));
+
+            Route::middleware(['web', 'auth:sanctum', 'verified', 'role:client'])
+                ->prefix('portal')
+                ->name('portal.')
+                ->group(base_path('routes/portal.php'));
+
+            Route::middleware('api')
+                ->prefix('api/v1')
+                ->group(base_path('routes/api.php'));
+        });
+    }
+}
+

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -1,12 +1,17 @@
 <?php
 
+use App\Providers\AppServiceProvider;
+use App\Providers\RouteServiceProvider;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
 
 return Application::configure(basePath: dirname(__DIR__))
+    ->withProviders([
+        AppServiceProvider::class,
+        RouteServiceProvider::class,
+    ])
     ->withRouting(
-        web: __DIR__.'/../routes/web.php',
         commands: __DIR__.'/../routes/console.php',
         health: '/up',
     )
@@ -16,3 +21,4 @@ return Application::configure(basePath: dirname(__DIR__))
     ->withExceptions(function (Exceptions $exceptions): void {
         //
     })->create();
+

--- a/routes/admin.php
+++ b/routes/admin.php
@@ -1,0 +1,8 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+
+Route::get('/', function () {
+    return 'Admin Dashboard';
+});
+

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,0 +1,12 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+
+Route::post('/activate', function () {
+    return response()->json(['status' => 'activated']);
+});
+
+Route::post('/update', function () {
+    return response()->json(['status' => 'updated']);
+});
+

--- a/routes/portal.php
+++ b/routes/portal.php
@@ -1,0 +1,8 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+
+Route::get('/', function () {
+    return 'Client Portal';
+});
+

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,6 +2,10 @@
 
 use Illuminate\Support\Facades\Route;
 
-Route::get('/', function () {
-    return view('welcome');
-});
+Route::view('/', 'welcome')->name('home');
+
+Route::view('/contact', 'contact')->name('contact.show');
+Route::post('/contact', function () {
+    return back()->with('status', 'Message sent!');
+})->name('contact.submit');
+


### PR DESCRIPTION
## Summary
- Organize public, admin, portal, and API routes into dedicated files
- Introduce RouteServiceProvider to register route groups with proper middleware
- Update bootstrap configuration to load route service provider

## Testing
- `composer install --no-progress --no-interaction` *(fails: CONNECT tunnel failed, response 403)*
- `composer test` *(fails: vendor/autoload.php missing)*

------
https://chatgpt.com/codex/tasks/task_e_689dcc220804833287fcf5379ea005f3