### PR TITLE
Convert approved quotes to invoices and handle payment receipts

### DIFF
--- a/app/Mail/PaymentReceipt.php
+++ b/app/Mail/PaymentReceipt.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Mail;
+
+use App\Models\Payment;
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Queue\SerializesModels;
+
+class PaymentReceipt extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    public function __construct(public Payment $payment)
+    {
+    }
+
+    public function build()
+    {
+        return $this->subject('Payment Receipt')
+            ->view('emails.payment-receipt', [
+                'payment' => $this->payment,
+            ]);
+    }
+}

--- a/app/Models/Invoice.php
+++ b/app/Models/Invoice.php
@@ -3,8 +3,47 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class Invoice extends Model
 {
-    //
+    /**
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        'order_id',
+        'number',
+        'subtotal',
+        'discount_total',
+        'tax_total',
+        'grand_total',
+        'status',
+        'due_at',
+    ];
+
+    /**
+     * The order this invoice belongs to.
+     */
+    public function order(): BelongsTo
+    {
+        return $this->belongsTo(Order::class);
+    }
+
+    /**
+     * Payments made against the invoice.
+     */
+    public function payments(): HasMany
+    {
+        return $this->hasMany(Payment::class);
+    }
+
+    /**
+     * Mark invoice as paid.
+     */
+    public function markPaid(): void
+    {
+        $this->status = 'paid';
+        $this->save();
+    }
 }

--- a/app/Models/Order.php
+++ b/app/Models/Order.php
@@ -3,8 +3,33 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasOne;
+use App\Models\User;
+use App\Models\License;
 
 class Order extends Model
 {
-    //
+    /**
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        'user_id',
+    ];
+
+    /**
+     * Order belongs to a user.
+     */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    /**
+     * License associated with the order.
+     */
+    public function license(): HasOne
+    {
+        return $this->hasOne(License::class);
+    }
 }

--- a/app/Models/Payment.php
+++ b/app/Models/Payment.php
@@ -2,9 +2,54 @@
 
 namespace App\Models;
 
+use App\Mail\PaymentReceipt;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Facades\Mail;
+use App\Models\Invoice;
 
 class Payment extends Model
 {
-    //
+    /**
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        'invoice_id',
+        'provider',
+        'provider_txn_id',
+        'amount',
+        'currency',
+        'status',
+        'paid_at',
+    ];
+
+    protected static function booted(): void
+    {
+        static::created(function (Payment $payment): void {
+            $invoice = $payment->invoice;
+
+            if ($payment->status === 'succeeded' && $invoice) {
+                $invoice->markPaid();
+
+                // Update associated license
+                if ($invoice->order && $invoice->order->license) {
+                    $invoice->order->license->touch();
+                }
+
+                // Send receipt email
+                if ($invoice->order && $invoice->order->user) {
+                    Mail::to($invoice->order->user->email)
+                        ->send(new PaymentReceipt($payment));
+                }
+            }
+        });
+    }
+
+    /**
+     * Payment belongs to an invoice.
+     */
+    public function invoice(): BelongsTo
+    {
+        return $this->belongsTo(Invoice::class);
+    }
 }

--- a/app/Models/Quote.php
+++ b/app/Models/Quote.php
@@ -2,9 +2,58 @@
 
 namespace App\Models;
 
+use App\Notifications\QuoteApproved;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use App\Models\Invoice;
+use App\Models\User;
 
 class Quote extends Model
 {
-    //
+    /**
+     * Fields that can be mass assigned.
+     *
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        'status',
+        'number',
+        'subtotal',
+        'discount_total',
+        'tax_total',
+        'grand_total',
+        'user_id',
+    ];
+
+    /**
+     * Quote belongs to a user (client).
+     */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    /**
+     * Approve the quote, create an invoice and notify the user.
+     */
+    public function approve(): Invoice
+    {
+        $this->status = 'approved';
+        $this->save();
+
+        $invoice = Invoice::create([
+            'order_id'       => $this->id, // simplistic mapping
+            'number'         => 'INV-' . $this->number,
+            'subtotal'       => $this->subtotal ?? 0,
+            'discount_total' => $this->discount_total ?? 0,
+            'tax_total'      => $this->tax_total ?? 0,
+            'grand_total'    => $this->grand_total ?? 0,
+        ]);
+
+        if ($this->user) {
+            $this->user->notify(new QuoteApproved($this, $invoice));
+        }
+
+        return $invoice;
+    }
 }

--- a/app/Notifications/QuoteApproved.php
+++ b/app/Notifications/QuoteApproved.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Notifications;
+
+use App\Models\Quote;
+use App\Models\Invoice;
+use Illuminate\Bus\Queueable;
+use Illuminate\Notifications\Notification;
+use Illuminate\Notifications\Messages\MailMessage;
+
+class QuoteApproved extends Notification
+{
+    use Queueable;
+
+    public function __construct(
+        protected Quote $quote,
+        protected Invoice $invoice
+    ) {
+    }
+
+    /**
+     * Get the notification's delivery channels.
+     */
+    public function via($notifiable): array
+    {
+        return ['mail'];
+    }
+
+    /**
+     * Get the mail representation of the notification.
+     */
+    public function toMail($notifiable): MailMessage
+    {
+        return (new MailMessage)
+            ->subject('Quote Approved')
+            ->line('Your quote #' . $this->quote->number . ' has been approved.')
+            ->action('View Invoice', url('/invoices/' . $this->invoice->id));
+    }
+}

--- a/resources/views/emails/payment-receipt.blade.php
+++ b/resources/views/emails/payment-receipt.blade.php
@@ -1,0 +1,1 @@
+Payment of {{ number_format($payment->amount, 2) }} {{ $payment->currency }} received for invoice #{{ $payment->invoice->number }}.


### PR DESCRIPTION
## Summary
- convert approved quotes to invoices and notify clients
- mark invoices paid on payment and send receipt emails

## Testing
- `composer install --no-interaction --no-progress` *(fails: CONNECT tunnel failed 403)*

------
https://chatgpt.com/codex/tasks/task_e_689dcc25c92083328de45d19881bcc06