### PR TITLE
Auto-create leads and quotes for service requests

### DIFF
--- a/app/Models/Lead.php
+++ b/app/Models/Lead.php
@@ -6,5 +6,8 @@ use Illuminate\Database\Eloquent\Model;
 
 class Lead extends Model
 {
-    //
+    /**
+     * The attributes that aren't mass assignable.
+     */
+    protected $guarded = [];
 }

--- a/app/Models/PipelineStage.php
+++ b/app/Models/PipelineStage.php
@@ -6,5 +6,8 @@ use Illuminate\Database\Eloquent\Model;
 
 class PipelineStage extends Model
 {
-    //
+    /**
+     * The attributes that aren't mass assignable.
+     */
+    protected $guarded = [];
 }

--- a/app/Models/Quote.php
+++ b/app/Models/Quote.php
@@ -6,5 +6,8 @@ use Illuminate\Database\Eloquent\Model;
 
 class Quote extends Model
 {
-    //
+    /**
+     * The attributes that aren't mass assignable.
+     */
+    protected $guarded = [];
 }

--- a/app/Models/ServiceRequest.php
+++ b/app/Models/ServiceRequest.php
@@ -3,8 +3,65 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Str;
+use function Spatie\Activitylog\activity;
 
 class ServiceRequest extends Model
 {
-    //
+    /**
+     * The attributes that aren't mass assignable.
+     */
+    protected $guarded = [];
+
+    /**
+     * Service related to the request.
+     */
+    public function service(): BelongsTo
+    {
+        return $this->belongsTo(Service::class);
+    }
+
+    /**
+     * Lead generated from the request.
+     */
+    public function lead(): BelongsTo
+    {
+        return $this->belongsTo(Lead::class);
+    }
+
+    /**
+     * Handle model events.
+     */
+    protected static function booted(): void
+    {
+        static::created(function (ServiceRequest $request): void {
+            $stage = PipelineStage::orderBy('order')->first();
+
+            $lead = Lead::create([
+                'name' => 'Lead #' . $request->id,
+                'source' => 'service-request',
+                'pipeline_stage_id' => $stage?->id,
+            ]);
+
+            $request->lead()->associate($lead);
+            $request->save();
+
+            $quote = Quote::create([
+                'lead_id' => $lead->id,
+                'number' => Str::uuid(),
+                'status' => 'draft',
+            ]);
+
+            activity()->performedOn($request)->withProperties([
+                'lead_id' => $lead->id,
+                'quote_id' => $quote->id,
+            ])->log('service_request_submitted');
+
+            activity()->performedOn($lead)->log('lead_created_from_service_request');
+
+            activity()->performedOn($quote)->log('draft_quote_created');
+        });
+    }
 }
+

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
     "require": {
         "php": "^8.2",
         "laravel/framework": "^12.0",
-        "laravel/tinker": "^2.10.1"
+        "laravel/tinker": "^2.10.1",
+        "spatie/laravel-activitylog": "^4.7"
     },
     "require-dev": {
         "fakerphp/faker": "^1.23",


### PR DESCRIPTION
## Summary
- auto-generate a lead and draft quote when service requests are submitted
- log service request, lead, and quote creation via spatie activity log
- allow mass-assignment on lead, quote, and pipeline stage models; require activity log package

## Testing
- `composer test` *(fails: require(/workspace/PERFEXDEV-360/vendor/autoload.php): No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689dcc2809f48332aa98ef869703c981