### PR TITLE
seed core models with factories

### DIFF
--- a/app/Models/BlogPost.php
+++ b/app/Models/BlogPost.php
@@ -6,5 +6,10 @@ use Illuminate\Database\Eloquent\Model;
 
 class BlogPost extends Model
 {
-    //
+    protected $guarded = [];
+
+    public function author()
+    {
+        return $this->belongsTo(User::class, 'author_id');
+    }
 }

--- a/app/Models/Invoice.php
+++ b/app/Models/Invoice.php
@@ -6,5 +6,10 @@ use Illuminate\Database\Eloquent\Model;
 
 class Invoice extends Model
 {
-    //
+    protected $guarded = [];
+
+    public function order()
+    {
+        return $this->belongsTo(Order::class);
+    }
 }

--- a/app/Models/Lead.php
+++ b/app/Models/Lead.php
@@ -6,5 +6,20 @@ use Illuminate\Database\Eloquent\Model;
 
 class Lead extends Model
 {
-    //
+    protected $guarded = [];
+
+    public function pipelineStage()
+    {
+        return $this->belongsTo(PipelineStage::class);
+    }
+
+    public function assignedTo()
+    {
+        return $this->belongsTo(User::class, 'assigned_to_id');
+    }
+
+    public function quotes()
+    {
+        return $this->hasMany(Quote::class);
+    }
 }

--- a/app/Models/License.php
+++ b/app/Models/License.php
@@ -6,5 +6,15 @@ use Illuminate\Database\Eloquent\Model;
 
 class License extends Model
 {
-    //
+    protected $guarded = [];
+
+    public function product()
+    {
+        return $this->belongsTo(Product::class);
+    }
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
 }

--- a/app/Models/Order.php
+++ b/app/Models/Order.php
@@ -6,5 +6,15 @@ use Illuminate\Database\Eloquent\Model;
 
 class Order extends Model
 {
-    //
+    protected $guarded = [];
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function invoices()
+    {
+        return $this->hasMany(Invoice::class);
+    }
 }

--- a/app/Models/Page.php
+++ b/app/Models/Page.php
@@ -6,5 +6,5 @@ use Illuminate\Database\Eloquent\Model;
 
 class Page extends Model
 {
-    //
+    protected $guarded = [];
 }

--- a/app/Models/PipelineStage.php
+++ b/app/Models/PipelineStage.php
@@ -6,5 +6,5 @@ use Illuminate\Database\Eloquent\Model;
 
 class PipelineStage extends Model
 {
-    //
+    protected $guarded = [];
 }

--- a/app/Models/Product.php
+++ b/app/Models/Product.php
@@ -6,5 +6,15 @@ use Illuminate\Database\Eloquent\Model;
 
 class Product extends Model
 {
-    //
+    protected $guarded = [];
+
+    public function versions()
+    {
+        return $this->hasMany(Version::class);
+    }
+
+    public function licenses()
+    {
+        return $this->hasMany(License::class);
+    }
 }

--- a/app/Models/Project.php
+++ b/app/Models/Project.php
@@ -6,5 +6,15 @@ use Illuminate\Database\Eloquent\Model;
 
 class Project extends Model
 {
-    //
+    protected $guarded = [];
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function tickets()
+    {
+        return $this->hasMany(Ticket::class);
+    }
 }

--- a/app/Models/Quote.php
+++ b/app/Models/Quote.php
@@ -6,5 +6,15 @@ use Illuminate\Database\Eloquent\Model;
 
 class Quote extends Model
 {
-    //
+    protected $guarded = [];
+
+    public function lead()
+    {
+        return $this->belongsTo(Lead::class);
+    }
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
 }

--- a/app/Models/ReleaseChannel.php
+++ b/app/Models/ReleaseChannel.php
@@ -6,5 +6,5 @@ use Illuminate\Database\Eloquent\Model;
 
 class ReleaseChannel extends Model
 {
-    //
+    protected $guarded = [];
 }

--- a/app/Models/Ticket.php
+++ b/app/Models/Ticket.php
@@ -6,5 +6,15 @@ use Illuminate\Database\Eloquent\Model;
 
 class Ticket extends Model
 {
-    //
+    protected $guarded = [];
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function project()
+    {
+        return $this->belongsTo(Project::class);
+    }
 }

--- a/app/Models/Version.php
+++ b/app/Models/Version.php
@@ -6,5 +6,15 @@ use Illuminate\Database\Eloquent\Model;
 
 class Version extends Model
 {
-    //
+    protected $guarded = [];
+
+    public function product()
+    {
+        return $this->belongsTo(Product::class);
+    }
+
+    public function releaseChannel()
+    {
+        return $this->belongsTo(ReleaseChannel::class);
+    }
 }

--- a/database/factories/BlogPostFactory.php
+++ b/database/factories/BlogPostFactory.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\BlogPost;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends Factory<BlogPost>
+ */
+class BlogPostFactory extends Factory
+{
+    protected $model = BlogPost::class;
+
+    public function definition(): array
+    {
+        $title = $this->faker->sentence();
+        return [
+            'title' => $title,
+            'slug' => Str::slug($title) . '-' . $this->faker->unique()->numberBetween(1, 1000),
+            'body' => $this->faker->paragraph(),
+            'seo' => ['title' => $title],
+            'is_published' => true,
+            'published_at' => now(),
+        ];
+    }
+}

--- a/database/factories/InvoiceFactory.php
+++ b/database/factories/InvoiceFactory.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Invoice;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Invoice>
+ */
+class InvoiceFactory extends Factory
+{
+    protected $model = Invoice::class;
+
+    public function definition(): array
+    {
+        $subtotal = $this->faker->randomFloat(2, 50, 500);
+        $tax = $subtotal * 0.1;
+        return [
+            'number' => $this->faker->unique()->numerify('INV-####'),
+            'currency' => 'USD',
+            'subtotal' => $subtotal,
+            'discount_total' => 0,
+            'tax_total' => $tax,
+            'grand_total' => $subtotal + $tax,
+            'status' => 'unpaid',
+            'due_at' => now()->addMonth(),
+        ];
+    }
+}

--- a/database/factories/LeadFactory.php
+++ b/database/factories/LeadFactory.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Lead;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Lead>
+ */
+class LeadFactory extends Factory
+{
+    protected $model = Lead::class;
+
+    public function definition(): array
+    {
+        return [
+            'name' => $this->faker->name(),
+            'email' => $this->faker->safeEmail(),
+            'phone' => $this->faker->phoneNumber(),
+            'company' => $this->faker->company(),
+            'source' => $this->faker->randomElement(['contact','quote','project-brief','service-request']),
+            'budget_min' => $this->faker->numberBetween(1000, 5000),
+            'budget_max' => $this->faker->numberBetween(5000, 10000),
+            'timeline' => $this->faker->word(),
+            'tech_stack' => $this->faker->word(),
+            'notes' => $this->faker->sentence(),
+        ];
+    }
+}

--- a/database/factories/LicenseFactory.php
+++ b/database/factories/LicenseFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\License;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends Factory<License>
+ */
+class LicenseFactory extends Factory
+{
+    protected $model = License::class;
+
+    public function definition(): array
+    {
+        return [
+            'license_key' => Str::upper(Str::random(16)),
+            'type' => $this->faker->randomElement(['single','multi','enterprise']),
+            'activation_limit' => 1,
+            'update_window_ends_at' => now()->addYear(),
+            'is_revoked' => false,
+        ];
+    }
+}

--- a/database/factories/OrderFactory.php
+++ b/database/factories/OrderFactory.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Order;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Order>
+ */
+class OrderFactory extends Factory
+{
+    protected $model = Order::class;
+
+    public function definition(): array
+    {
+        $subtotal = $this->faker->randomFloat(2, 50, 500);
+        $tax = $subtotal * 0.1;
+        return [
+            'number' => $this->faker->unique()->numerify('O-####'),
+            'currency' => 'USD',
+            'subtotal' => $subtotal,
+            'discount_total' => 0,
+            'tax_total' => $tax,
+            'grand_total' => $subtotal + $tax,
+            'status' => 'paid',
+            'billing_info' => [],
+        ];
+    }
+}

--- a/database/factories/PageFactory.php
+++ b/database/factories/PageFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Page;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends Factory<Page>
+ */
+class PageFactory extends Factory
+{
+    protected $model = Page::class;
+
+    public function definition(): array
+    {
+        $title = $this->faker->sentence();
+        return [
+            'title' => $title,
+            'slug' => Str::slug($title) . '-' . $this->faker->unique()->numberBetween(1, 1000),
+            'seo' => ['title' => $title],
+            'is_published' => true,
+        ];
+    }
+}

--- a/database/factories/PipelineStageFactory.php
+++ b/database/factories/PipelineStageFactory.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\PipelineStage;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<PipelineStage>
+ */
+class PipelineStageFactory extends Factory
+{
+    protected $model = PipelineStage::class;
+
+    public function definition(): array
+    {
+        return [
+            'name' => $this->faker->unique()->randomElement(['New','Qualified','Proposal','Won','Lost']),
+            'order' => $this->faker->unique()->numberBetween(1, 10),
+        ];
+    }
+}

--- a/database/factories/ProductFactory.php
+++ b/database/factories/ProductFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Product;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends Factory<Product>
+ */
+class ProductFactory extends Factory
+{
+    protected $model = Product::class;
+
+    public function definition(): array
+    {
+        $name = $this->faker->unique()->words(3, true);
+        return [
+            'type' => $this->faker->randomElement(['ERP', 'Module']),
+            'name' => $name,
+            'slug' => Str::slug($name) . '-' . $this->faker->unique()->numberBetween(1, 1000),
+            'summary' => $this->faker->sentence(),
+            'description' => $this->faker->paragraph(),
+            'seo' => ['title' => $name, 'description' => $this->faker->sentence()],
+            'is_active' => true,
+        ];
+    }
+}

--- a/database/factories/ProjectFactory.php
+++ b/database/factories/ProjectFactory.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Project;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Project>
+ */
+class ProjectFactory extends Factory
+{
+    protected $model = Project::class;
+
+    public function definition(): array
+    {
+        return [
+            'name' => $this->faker->words(3, true),
+            'status' => $this->faker->randomElement(['active','on_hold','completed']),
+            'start_at' => now(),
+            'due_at' => now()->addMonths(2),
+        ];
+    }
+}

--- a/database/factories/QuoteFactory.php
+++ b/database/factories/QuoteFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Quote;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Quote>
+ */
+class QuoteFactory extends Factory
+{
+    protected $model = Quote::class;
+
+    public function definition(): array
+    {
+        $subtotal = $this->faker->randomFloat(2, 100, 1000);
+        $tax = $subtotal * 0.2;
+        return [
+            'number' => $this->faker->unique()->numerify('Q-####'),
+            'status' => $this->faker->randomElement(['draft','sent','approved']),
+            'valid_until' => now()->addDays(30),
+            'subtotal' => $subtotal,
+            'discount_total' => 0,
+            'tax_total' => $tax,
+            'grand_total' => $subtotal + $tax,
+        ];
+    }
+}

--- a/database/factories/ReleaseChannelFactory.php
+++ b/database/factories/ReleaseChannelFactory.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\ReleaseChannel;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<ReleaseChannel>
+ */
+class ReleaseChannelFactory extends Factory
+{
+    protected $model = ReleaseChannel::class;
+
+    public function definition(): array
+    {
+        return [
+            'name' => $this->faker->unique()->randomElement(['stable','beta','rc']),
+        ];
+    }
+}

--- a/database/factories/TicketFactory.php
+++ b/database/factories/TicketFactory.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Ticket;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Ticket>
+ */
+class TicketFactory extends Factory
+{
+    protected $model = Ticket::class;
+
+    public function definition(): array
+    {
+        return [
+            'subject' => $this->faker->sentence(),
+            'category' => $this->faker->word(),
+            'priority' => $this->faker->randomElement(['low','normal','high','urgent']),
+            'status' => $this->faker->randomElement(['open','pending','resolved','closed']),
+            'last_activity_at' => now(),
+        ];
+    }
+}

--- a/database/factories/VersionFactory.php
+++ b/database/factories/VersionFactory.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Version;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Version>
+ */
+class VersionFactory extends Factory
+{
+    protected $model = Version::class;
+
+    public function definition(): array
+    {
+        return [
+            'number' => $this->faker->unique()->semver(),
+            'is_published' => true,
+            'notes' => ['changelog' => $this->faker->sentence()],
+            'forced_update' => false,
+            'released_at' => now(),
+        ];
+    }
+}

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -2,8 +2,7 @@
 
 namespace Database\Seeders;
 
-use App\Models\User;
-// use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use App\Models\{BlogPost, Invoice, Lead, License, Order, Page, PipelineStage, Product, Project, Quote, ReleaseChannel, Ticket, User, Version};
 use Illuminate\Database\Seeder;
 
 class DatabaseSeeder extends Seeder
@@ -13,11 +12,38 @@ class DatabaseSeeder extends Seeder
      */
     public function run(): void
     {
-        // User::factory(10)->create();
+        $users = User::factory(10)->create();
 
-        User::factory()->create([
-            'name' => 'Test User',
-            'email' => 'test@example.com',
-        ]);
+        Page::factory(5)->create();
+        BlogPost::factory(5)->for($users->random(), 'author')->create();
+
+        $channels = ReleaseChannel::factory()->count(3)->create();
+
+        Product::factory()
+            ->count(5)
+            ->has(Version::factory()->count(3)->state(fn () => ['release_channel_id' => $channels->random()->id]))
+            ->has(License::factory()->count(2)->for($users->random()))
+            ->create();
+
+        $stages = PipelineStage::factory()->count(4)->create();
+
+        Lead::factory()
+            ->count(10)
+            ->for($stages->random(), 'pipelineStage')
+            ->for($users->random(), 'assignedTo')
+            ->has(Quote::factory()->count(1)->for($users->random()))
+            ->create();
+
+        Order::factory()
+            ->count(5)
+            ->for($users->random())
+            ->has(Invoice::factory())
+            ->create();
+
+        Project::factory()
+            ->count(3)
+            ->for($users->random())
+            ->has(Ticket::factory()->count(2)->for($users->random()))
+            ->create();
     }
 }


### PR DESCRIPTION
## Summary
- add factories and relationships for products, releases, licenses, leads, quotes, invoices, tickets, projects, blog posts and pages
- populate database seeder with factory-driven dataset

## Testing
- `php artisan test` *(fails: vendor autoload not found)*
- `composer install` *(fails: GitHub API returned 403)*

------
https://chatgpt.com/codex/tasks/task_e_689dcc32ae84833284a01b6659d73f1a