### PR TITLE
feat(core): add feature flags and CTA phone seeding

### DIFF
--- a/Roadmap.md
+++ b/Roadmap.md
@@ -33,7 +33,7 @@ Here you go — a single, copy-paste **MASTER PROMPT** that generates the comple
 
 * **Tailwind + Alpine only** for interactivity.
 * Component-first Blade architecture. Reusable, documented components.
-* Feature flags for risky/AI features (`config/features.php`).
+* Feature flags for risky/AI features (`config/features.php`). ✅ Done — 2025-08-15 (commit: <hash>)
 
 ---
 
@@ -451,3 +451,10 @@ SITEMAP_ENABLE=true
 * CI workflow, Docker files, README, Postman & OpenAPI docs
 
 **Non-negotiables:** Tailwind+Alpine only, clean modular code, strong tests, secure defaults, SEO-ready, **03390123735** surfaced in configured CTAs.
+
+## Build Log
+
+- 2025-08-15T14:26:57Z — Sprint 0 — Feature flags & CTA phone seeding — ✅ Done (commit: <hash>)
+  - Added: config/features.php, database/seeders/SettingSeeder.php, resources/views/components/cta.blade.php, tests/Feature/CtaComponentTest.php
+  - Modified: app/Models/Setting.php, database/seeders/DatabaseSeeder.php, Roadmap.md
+  - Notes: AI content feature flag introduced; default phone 03390123735 seeded and displayed via CTA component

--- a/app/Models/Setting.php
+++ b/app/Models/Setting.php
@@ -6,5 +6,8 @@ use Illuminate\Database\Eloquent\Model;
 
 class Setting extends Model
 {
-    //
+    /**
+     * The attributes that aren't mass assignable.
+     */
+    protected $guarded = [];
 }

--- a/config/features.php
+++ b/config/features.php
@@ -1,0 +1,16 @@
+<?php
+
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | Application Feature Flags
+    |--------------------------------------------------------------------------
+    |
+    | This configuration controls feature toggles for risky or optional
+    | functionality. Features can be enabled via environment variables.
+    |
+    */
+
+    'ai_content' => env('FEATURES_AI_CONTENT', false),
+];
+

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -5,6 +5,10 @@ namespace Database\Seeders;
 use App\Models\{BlogPost, Invoice, Lead, License, Order, Page, PipelineStage, Product, Project, Quote, ReleaseChannel, Ticket, User, Version};
 use Illuminate\Database\Seeder;
 
+/**
+ * @see \Database\Seeders\SettingSeeder
+ */
+
 class DatabaseSeeder extends Seeder
 {
     /**
@@ -12,6 +16,8 @@ class DatabaseSeeder extends Seeder
      */
     public function run(): void
     {
+        $this->call(SettingSeeder::class);
+
         $users = User::factory(9)->create();
         $admin = User::factory()->create([
             'name' => 'Admin User',

--- a/database/seeders/SettingSeeder.php
+++ b/database/seeders/SettingSeeder.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Setting;
+use Illuminate\Database\Seeder;
+
+class SettingSeeder extends Seeder
+{
+    public function run(): void
+    {
+        Setting::updateOrCreate(
+            ['key' => 'cta_phone'],
+            ['value' => '03390123735']
+        );
+    }
+}
+

--- a/resources/views/components/cta.blade.php
+++ b/resources/views/components/cta.blade.php
@@ -1,0 +1,6 @@
+@php
+    $phone = \App\Models\Setting::where('key', 'cta_phone')->value('value') ?? '03390123735';
+@endphp
+<a href="tel:{{ $phone }}" class="inline-flex items-center font-semibold text-blue-600 hover:underline">
+    {{ $slot->isEmpty() ? 'Call or WhatsApp ' . $phone : $slot }}
+</a>

--- a/tests/Feature/CtaComponentTest.php
+++ b/tests/Feature/CtaComponentTest.php
@@ -1,0 +1,16 @@
+<?php
+
+use App\Models\Setting;
+use Database\Seeders\SettingSeeder;
+use function Pest\Laravel\blade;
+use function Pest\Laravel\seed;
+
+it('seeds phone number and displays in CTA component', function () {
+    seed(SettingSeeder::class);
+
+    expect(Setting::where('key', 'cta_phone')->value('value'))
+        ->toBe('03390123735');
+
+    blade('<x-cta />')
+        ->assertSee('03390123735');
+});


### PR DESCRIPTION
## Summary
- introduce configurable feature flags via `config/features.php`
- seed default CTA phone number and expose via new `<x-cta>` component
- add tests ensuring seeded phone appears in CTA component

## Testing
- `php artisan test` *(fails: vendor/autoload.php missing; composer install could not complete due to GitHub proxy restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_689f42ff22b08332b39592b309b7630d