### PR TITLE
Add CI workflow for Pint, PHPStan, and Pest tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          coverage: none
+          cache: 'composer'
+
+      - name: Cache vendor
+        uses: actions/cache@v3
+        with:
+          path: vendor
+          key: ${{ runner.os }}-vendor-${{ hashFiles('composer.lock') }}
+          restore-keys: ${{ runner.os }}-vendor-
+
+      - name: Install dependencies
+        run: composer install --no-interaction --prefer-dist --no-progress
+
+      - name: Pint
+        run: vendor/bin/pint --test
+
+      - name: PHPStan
+        run: vendor/bin/phpstan analyse --level=8
+
+      - name: Tests
+        run: php artisan test


### PR DESCRIPTION
## Summary
- run Pint, PHPStan (level 8), and `php artisan test` in GitHub Actions
- cache Composer vendor directory for faster installs

## Testing
- ⚠️ `composer install` (failed: GitHub token required)
- ⚠️ `vendor/bin/pint --test` (failed: No such file or directory)
- ⚠️ `vendor/bin/phpstan analyse --level=8` (failed: No such file or directory)
- ⚠️ `php artisan test` (failed: missing vendor autoload)


------
https://chatgpt.com/codex/tasks/task_e_689f575c94788332807682d9e1558fc8