### PR TITLE
Add contact form security and quote approval features

### DIFF
--- a/app/Http/Controllers/Frontend/ContactController.php
+++ b/app/Http/Controllers/Frontend/ContactController.php
@@ -5,8 +5,8 @@ namespace App\Http\Controllers\Frontend;
 use App\Http\Controllers\Controller;
 use App\Models\Lead;
 use Illuminate\Http\RedirectResponse;
-use Illuminate\Http\Request;
 use Illuminate\View\View;
+use App\Http\Requests\ContactRequest;
 
 class ContactController extends Controller
 {
@@ -21,14 +21,9 @@ class ContactController extends Controller
     /**
      * Store a new contact lead.
      */
-    public function store(Request $request): RedirectResponse
+    public function store(ContactRequest $request): RedirectResponse
     {
-        $validated = $request->validate([
-            'name' => ['required', 'string', 'max:255'],
-            'email' => ['required', 'email'],
-            'phone' => ['nullable', 'string', 'max:255'],
-            'message' => ['required', 'string'],
-        ]);
+        $validated = $request->validated();
 
         Lead::create([
             'name' => $validated['name'],

--- a/app/Http/Controllers/Portal/QuoteController.php
+++ b/app/Http/Controllers/Portal/QuoteController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Portal;
 use App\Http\Controllers\Controller;
 use App\Models\Quote;
 use Illuminate\Http\Request;
+use Illuminate\Http\RedirectResponse;
 
 class QuoteController extends Controller
 {
@@ -62,5 +63,17 @@ class QuoteController extends Controller
     public function destroy(Quote $quote)
     {
         //
+    }
+
+    public function approve(Request $request, Quote $quote): RedirectResponse
+    {
+        $validated = $request->validate([
+            'legal_name' => ['required', 'string'],
+            'accept_terms' => ['accepted'],
+        ]);
+
+        $quote->approve($validated['legal_name'], $request->ip());
+
+        return back()->with('status', 'Quote approved.');
     }
 }

--- a/app/Http/Requests/ContactRequest.php
+++ b/app/Http/Requests/ContactRequest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class ContactRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'name' => ['required', 'string', 'max:255'],
+            'email' => ['required', 'email'],
+            'phone' => ['nullable', 'string', 'max:255'],
+            'message' => ['required', 'string'],
+            'website' => ['prohibited'], // honeypot field
+        ];
+    }
+}

--- a/app/Models/Meeting.php
+++ b/app/Models/Meeting.php
@@ -3,8 +3,22 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Str;
+use App\Models\Setting;
 
 class Meeting extends Model
 {
-    //
+    protected $guarded = [];
+
+    protected static function booted(): void
+    {
+        static::creating(function (Meeting $meeting): void {
+            if ($meeting->provider === 'google_meet' && empty($meeting->url)) {
+                $template = Setting::firstWhere('key', 'google_meet_template')?->value
+                    ?? 'https://meet.google.com/{code}';
+                $code = Str::lower(Str::random(3)) . '-' . Str::lower(Str::random(4)) . '-' . Str::lower(Str::random(3));
+                $meeting->url = str_replace('{code}', $code, $template);
+            }
+        });
+    }
 }

--- a/app/Models/QuoteItem.php
+++ b/app/Models/QuoteItem.php
@@ -3,8 +3,34 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class QuoteItem extends Model
 {
-    //
+    protected $guarded = [];
+
+    public function quote(): BelongsTo
+    {
+        return $this->belongsTo(Quote::class);
+    }
+
+    public function getLineTotalAttribute(): float
+    {
+        return $this->qty * $this->unit_price - $this->discount;
+    }
+
+    public function getTaxAmountAttribute(): float
+    {
+        return $this->line_total * ($this->tax_rate / 100);
+    }
+
+    protected static function booted(): void
+    {
+        static::saved(function (QuoteItem $item): void {
+            $item->quote?->recalculateTotals();
+        });
+        static::deleted(function (QuoteItem $item): void {
+            $item->quote?->recalculateTotals();
+        });
+    }
 }

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -4,6 +4,9 @@ namespace App\Providers;
 
 use Illuminate\Foundation\Support\Providers\RouteServiceProvider as ServiceProvider;
 use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Facades\RateLimiter;
+use Illuminate\Cache\RateLimiting\Limit;
+use Illuminate\Http\Request;
 
 class RouteServiceProvider extends ServiceProvider
 {
@@ -12,6 +15,10 @@ class RouteServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
+        RateLimiter::for('contact', function (Request $request) {
+            return Limit::perMinute(5)->by($request->ip());
+        });
+
         $this->routes(function () {
             Route::middleware('web')
                 ->group(base_path('routes/web.php'));

--- a/app/Services/FlowService.php
+++ b/app/Services/FlowService.php
@@ -6,6 +6,7 @@ use App\Models\{Invoice, Lead, LeadStageChange, License, LicenseActivation, Orde
 use App\Models\Payment;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
+use function Spatie\Activitylog\activity;
 
 /**
  * High level orchestration for common business flows.
@@ -91,6 +92,13 @@ class FlowService
             'to_stage_id' => $stage->id,
             'changed_by' => $actor?->id,
         ]);
+
+        activity()
+            ->performedOn($lead)
+            ->withProperties([
+                'from' => $from,
+                'to' => $stage->id,
+            ])->log('lead_stage_changed');
 
         return $lead;
     }

--- a/resources/views/frontend/contact.blade.php
+++ b/resources/views/frontend/contact.blade.php
@@ -24,6 +24,10 @@
         <textarea class="w-full border-gray-300 rounded" name="message" id="message" rows="5" required>{{ old('message') }}</textarea>
         @error('message')<p class="text-red-600 text-sm mt-1">{{ $message }}</p>@enderror
     </div>
+    <div class="hidden">
+        <label for="website">Website</label>
+        <input type="text" name="website" id="website" tabindex="-1" autocomplete="off">
+    </div>
     <button class="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700" type="submit">Send</button>
 </form>
 @endsection

--- a/routes/portal.php
+++ b/routes/portal.php
@@ -1,8 +1,12 @@
 <?php
 
 use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\Portal\QuoteController;
 
 Route::get('/', function () {
     return 'Client Portal';
 });
+
+Route::post('quotes/{quote}/approve', [QuoteController::class, 'approve'])
+    ->name('quotes.approve');
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -32,7 +32,9 @@ Route::post('/checkout/{product}', [CheckoutController::class, 'process'])->name
 Route::get('/services', [ServiceController::class, 'index'])->name('services.index');
 Route::get('/blog', [BlogController::class, 'index'])->name('blog.index');
 Route::get('/contact', [ContactController::class, 'index'])->name('contact.index');
-Route::post('/contact', [ContactController::class, 'store'])->name('contact.store');
+Route::post('/contact', [ContactController::class, 'store'])
+    ->middleware('throttle:contact')
+    ->name('contact.store');
 
 Route::get('/sitemap.xml', function () {
     return Sitemap::create()


### PR DESCRIPTION
## Summary
- protect contact form with dedicated request, honeypot field, and rate limiting
- support quote line items, signature-based approval, and invoice conversion
- auto-generate Google Meet links and log lead stage changes

## Testing
- `composer test` *(fails: Script @php artisan config:clear --ansi handling the test event returned with error code 255)*
- `php -l app/Models/Quote.php app/Models/QuoteItem.php app/Models/Meeting.php app/Http/Controllers/Frontend/ContactController.php app/Http/Requests/ContactRequest.php app/Providers/RouteServiceProvider.php app/Services/FlowService.php routes/web.php routes/portal.php app/Http/Controllers/Portal/QuoteController.php resources/views/frontend/contact.blade.php`

------
https://chatgpt.com/codex/tasks/task_e_689f6522c0e48332b3942c1b3d657e47