### PR TITLE
Implement service RFQ flow and matcher

### DIFF
--- a/app/Http/Controllers/Frontend/RfqController.php
+++ b/app/Http/Controllers/Frontend/RfqController.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Http\Controllers\Frontend;
+
+use App\Http\Controllers\Controller;
+use App\Models\LeadAttachment;
+use App\Models\Service;
+use App\Models\ServiceRequest;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+
+class RfqController extends Controller
+{
+    /**
+     * Store a new RFQ and generate related lead and quote.
+     */
+    public function store(Request $request, Service $service): RedirectResponse
+    {
+        $data = $request->validate([
+            'options' => ['array'],
+            'options.*' => ['nullable'],
+            'notes' => ['nullable', 'string'],
+            'files.*' => ['file', 'max:10240'],
+        ]);
+
+        $serviceRequest = ServiceRequest::create([
+            'service_id' => $service->id,
+            'selected_options' => $data['options'] ?? [],
+            'notes' => $data['notes'] ?? null,
+        ]);
+
+        $serviceRequest->refresh();
+
+        if ($request->hasFile('files')) {
+            foreach ($request->file('files') as $file) {
+                $path = $file->store('leads');
+
+                LeadAttachment::create([
+                    'lead_id' => $serviceRequest->lead_id,
+                    'path' => $path,
+                    'disk' => config('filesystems.default'),
+                    'size' => $file->getSize(),
+                    'mime' => $file->getClientMimeType(),
+                    'original_name' => $file->getClientOriginalName(),
+                ]);
+            }
+        }
+
+        return redirect()->route('services.show', $service)->with('status', 'Request submitted');
+    }
+}

--- a/app/Http/Controllers/Frontend/ServiceController.php
+++ b/app/Http/Controllers/Frontend/ServiceController.php
@@ -3,15 +3,28 @@
 namespace App\Http\Controllers\Frontend;
 
 use App\Http\Controllers\Controller;
+use App\Models\Service;
 use Illuminate\View\View;
 
 class ServiceController extends Controller
 {
     /**
-     * Display the services page.
+     * Display a listing of services.
      */
     public function index(): View
     {
-        return view('frontend.services');
+        $services = Service::where('is_active', true)->get();
+
+        return view('services.index', compact('services'));
+    }
+
+    /**
+     * Display a specific service.
+     */
+    public function show(Service $service): View
+    {
+        $service->load(['options', 'faqs', 'caseStudies']);
+
+        return view('services.show', compact('service'));
     }
 }

--- a/app/Models/LeadAttachment.php
+++ b/app/Models/LeadAttachment.php
@@ -2,9 +2,24 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class LeadAttachment extends Model
 {
-    //
+    use HasFactory;
+
+    /**
+     * The attributes that aren't mass assignable.
+     */
+    protected $guarded = [];
+
+    /**
+     * Lead the attachment belongs to.
+     */
+    public function lead(): BelongsTo
+    {
+        return $this->belongsTo(Lead::class);
+    }
 }

--- a/app/Models/Service.php
+++ b/app/Models/Service.php
@@ -2,9 +2,54 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
 
 class Service extends Model
 {
-    //
+    use HasFactory;
+
+    /**
+     * The attributes that aren't mass assignable.
+     */
+    protected $guarded = [];
+
+    /**
+     * Options available for the service.
+     */
+    public function options(): HasMany
+    {
+        return $this->hasMany(ServiceOption::class);
+    }
+
+    /**
+     * Frequently asked questions for the service.
+     */
+    public function faqs(): HasMany
+    {
+        return $this->hasMany(ServiceFAQ::class);
+    }
+
+    /**
+     * Related case studies.
+     */
+    public function caseStudies(): BelongsToMany
+    {
+        return $this->belongsToMany(CaseStudy::class);
+    }
+
+    /**
+     * Gather tag-like identifiers for the service for matching.
+     */
+    public function tags(): Collection
+    {
+        return collect([$this->category])
+            ->filter()
+            ->map(fn ($tag) => Str::slug($tag))
+            ->merge($this->options->pluck('slug'));
+    }
 }

--- a/app/Models/ServiceFAQ.php
+++ b/app/Models/ServiceFAQ.php
@@ -2,9 +2,24 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class ServiceFAQ extends Model
 {
-    //
+    use HasFactory;
+
+    /**
+     * The attributes that aren't mass assignable.
+     */
+    protected $guarded = [];
+
+    /**
+     * Service the FAQ belongs to.
+     */
+    public function service(): BelongsTo
+    {
+        return $this->belongsTo(Service::class);
+    }
 }

--- a/app/Models/ServiceOption.php
+++ b/app/Models/ServiceOption.php
@@ -2,9 +2,31 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class ServiceOption extends Model
 {
-    //
+    use HasFactory;
+
+    /**
+     * The attributes that aren't mass assignable.
+     */
+    protected $guarded = [];
+
+    /**
+     * Attribute casting.
+     */
+    protected $casts = [
+        'config' => 'array',
+    ];
+
+    /**
+     * Service this option belongs to.
+     */
+    public function service(): BelongsTo
+    {
+        return $this->belongsTo(Service::class);
+    }
 }

--- a/app/Models/ServiceRequest.php
+++ b/app/Models/ServiceRequest.php
@@ -15,6 +15,13 @@ class ServiceRequest extends Model
     protected $guarded = [];
 
     /**
+     * Attribute casting.
+     */
+    protected $casts = [
+        'selected_options' => 'array',
+    ];
+
+    /**
      * Service related to the request.
      */
     public function service(): BelongsTo

--- a/app/Services/ServiceMatcher.php
+++ b/app/Services/ServiceMatcher.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Lead;
+use App\Models\Service;
+use Illuminate\Support\Collection;
+
+class ServiceMatcher
+{
+    /**
+     * Suggest services for a given lead using tag overlap.
+     */
+    public function suggestForLead(Lead $lead): Collection
+    {
+        $leadTags = collect(explode(',', (string) $lead->tech_stack))
+            ->map(fn ($tag) => trim(strtolower($tag)))
+            ->filter();
+
+        return Service::with('options')
+            ->get()
+            ->map(function (Service $service) use ($leadTags) {
+                $score = $leadTags->intersect($service->tags())->count();
+
+                return ['service' => $service, 'score' => $score];
+            })
+            ->filter(fn ($data) => $data['score'] > 0)
+            ->sortByDesc('score')
+            ->pluck('service');
+    }
+}

--- a/resources/views/components/service-card.blade.php
+++ b/resources/views/components/service-card.blade.php
@@ -1,0 +1,35 @@
+@props(['service'])
+
+<div class="bg-white rounded-lg shadow p-6">
+    <h2 class="text-xl font-semibold mb-2">
+        <a href="{{ route('services.show', $service) }}" class="text-indigo-600 hover:underline">
+            {{ $service->name }}
+        </a>
+    </h2>
+    @if($service->summary)
+        <p class="text-gray-700 mb-2">{{ $service->summary }}</p>
+    @endif
+    <div class="text-sm text-gray-500 space-y-1">
+        @if($service->category)
+            <p>Category: {{ $service->category }}</p>
+        @endif
+        @if($service->lead_time_days)
+            <p>Lead time: {{ $service->lead_time_days }} days</p>
+        @endif
+        @if($service->min_price || $service->max_price)
+            <p>Price:
+                @if($service->min_price)
+                    ${{ number_format($service->min_price, 2) }}
+                @else
+                    ?
+                @endif
+                –
+                @if($service->max_price)
+                    ${{ number_format($service->max_price, 2) }}
+                @else
+                    ?
+                @endif
+            </p>
+        @endif
+    </div>
+</div>

--- a/resources/views/services/index.blade.php
+++ b/resources/views/services/index.blade.php
@@ -1,0 +1,10 @@
+@extends('layouts.frontend')
+
+@section('content')
+    <h1 class="text-4xl font-bold mb-8">Services</h1>
+    <div class="grid md:grid-cols-3 gap-6">
+        @foreach($services as $service)
+            <x-service-card :service="$service" />
+        @endforeach
+    </div>
+@endsection

--- a/resources/views/services/show.blade.php
+++ b/resources/views/services/show.blade.php
@@ -1,0 +1,60 @@
+@extends('layouts.frontend')
+
+@section('content')
+    <h1 class="text-4xl font-bold mb-4">{{ $service->name }}</h1>
+    @if($service->summary)
+        <p class="text-gray-700 mb-6">{{ $service->summary }}</p>
+    @endif
+    @if($service->body)
+        <div class="prose mb-6">{!! nl2br(e($service->body)) !!}</div>
+    @endif
+
+    <h2 class="text-2xl font-semibold mb-4">Request a Quote</h2>
+    <form action="{{ route('rfq.store', $service) }}" method="POST" enctype="multipart/form-data" class="space-y-4">
+        @csrf
+        @foreach($service->options as $option)
+            <div>
+                <label class="block font-medium mb-1">{{ $option->name }}</label>
+                @if($option->type === 'select')
+                    <select name="options[{{ $option->slug }}]" class="border rounded w-full p-2">
+                        @foreach($option->config['choices'] ?? [] as $choice)
+                            <option value="{{ $choice }}">{{ ucfirst($choice) }}</option>
+                        @endforeach
+                    </select>
+                @else
+                    <input type="checkbox" name="options[{{ $option->slug }}]" value="1" {{ $option->is_default ? 'checked' : '' }}>
+                @endif
+            </div>
+        @endforeach
+        <div>
+            <label class="block font-medium mb-1">Attachments</label>
+            <input type="file" name="files[]" multiple class="border rounded w-full p-2" />
+        </div>
+        <div>
+            <label class="block font-medium mb-1">Notes</label>
+            <textarea name="notes" class="border rounded w-full p-2"></textarea>
+        </div>
+        <button type="submit" class="cta-button text-white px-6 py-2 rounded">Submit</button>
+    </form>
+
+    @if($service->faqs->count())
+        <h2 class="text-2xl font-semibold mt-12 mb-4">FAQs</h2>
+        <div class="space-y-4">
+            @foreach($service->faqs as $faq)
+                <div>
+                    <h3 class="font-medium">{{ $faq->question }}</h3>
+                    <p class="text-gray-700">{{ $faq->answer }}</p>
+                </div>
+            @endforeach
+        </div>
+    @endif
+
+    @if($service->caseStudies->count())
+        <h2 class="text-2xl font-semibold mt-12 mb-4">Case Studies</h2>
+        <ul class="list-disc pl-5 space-y-1">
+            @foreach($service->caseStudies as $case)
+                <li>{{ $case->title }}</li>
+            @endforeach
+        </ul>
+    @endif
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -5,6 +5,7 @@ use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\Frontend\HomeController;
 use App\Http\Controllers\Frontend\ProductController;
 use App\Http\Controllers\Frontend\ServiceController;
+use App\Http\Controllers\Frontend\RfqController;
 use App\Http\Controllers\Frontend\BlogController;
 use App\Http\Controllers\Frontend\ContactController;
 use App\Http\Controllers\Frontend\CheckoutController;
@@ -30,6 +31,8 @@ Route::get('/products/{product:slug}', [ProductController::class, 'show'])->name
 Route::get('/checkout/{product}', [CheckoutController::class, 'show'])->name('checkout.show');
 Route::post('/checkout/{product}', [CheckoutController::class, 'process'])->name('checkout.process');
 Route::get('/services', [ServiceController::class, 'index'])->name('services.index');
+Route::get('/services/{service:slug}', [ServiceController::class, 'show'])->name('services.show');
+Route::post('/services/{service:slug}/rfq', [RfqController::class, 'store'])->name('rfq.store');
 Route::get('/blog', [BlogController::class, 'index'])->name('blog.index');
 Route::get('/contact', [ContactController::class, 'index'])->name('contact.index');
 Route::post('/contact', [ContactController::class, 'store'])->name('contact.store');


### PR DESCRIPTION
## Summary
- flesh out Service model with FAQs, options, and case study links
- add service listing & detail pages with RFQ form
- create RFQ controller and service matcher for lead-based suggestions

## Testing
- `composer test` *(fails: require vendor/autoload.php)*
- `composer install` *(fails: Required package missing in lock file)*

------
https://chatgpt.com/codex/tasks/task_e_689f65776a9883328a04a07b9d5a591e