### PR TITLE
Add quote approval tests and ensure accurate totals

### DIFF
--- a/app/Models/Quote.php
+++ b/app/Models/Quote.php
@@ -58,6 +58,9 @@ class Quote extends Model
      */
     public function approve(string $name, string $ip): Invoice
     {
+        // Ensure totals are current before approval
+        $this->recalculateTotals();
+
         $this->status = 'approved';
         $meta = $this->meta ?? [];
         $meta['signature'] = [

--- a/database/factories/QuoteItemFactory.php
+++ b/database/factories/QuoteItemFactory.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\QuoteItem;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<QuoteItem>
+ */
+class QuoteItemFactory extends Factory
+{
+    protected $model = QuoteItem::class;
+
+    public function definition(): array
+    {
+        return [
+            'title' => $this->faker->sentence(3),
+            'description' => $this->faker->sentence(),
+            'qty' => 1,
+            'unit_price' => $this->faker->randomFloat(2, 10, 100),
+            'tax_rate' => $this->faker->randomFloat(2, 0, 20),
+            'discount' => 0,
+        ];
+    }
+}
+

--- a/tests/Feature/QuoteApprovalTest.php
+++ b/tests/Feature/QuoteApprovalTest.php
@@ -1,0 +1,72 @@
+<?php
+
+use App\Models\{Quote, QuoteItem, Invoice};
+use function Pest\Laravel\post;
+
+it('calculates totals from line items', function () {
+    $quote = Quote::factory()->create([
+        'subtotal' => 0,
+        'discount_total' => 0,
+        'tax_total' => 0,
+        'grand_total' => 0,
+    ]);
+
+    QuoteItem::factory()->for($quote)->create([
+        'qty' => 2,
+        'unit_price' => 50,
+        'discount' => 5,
+        'tax_rate' => 10,
+    ]);
+
+    QuoteItem::factory()->for($quote)->create([
+        'qty' => 1,
+        'unit_price' => 100,
+        'discount' => 0,
+        'tax_rate' => 20,
+    ]);
+
+    $quote->refresh();
+
+    expect($quote->subtotal)->toBe('200.00');
+    expect($quote->discount_total)->toBe('5.00');
+    expect($quote->tax_total)->toBe('29.50');
+    expect($quote->grand_total)->toBe('224.50');
+});
+
+it('approves a quote via e-sign and creates an invoice', function () {
+    $quote = Quote::factory()->create([
+        'subtotal' => 0,
+        'discount_total' => 0,
+        'tax_total' => 0,
+        'grand_total' => 0,
+    ]);
+
+    QuoteItem::factory()->for($quote)->create([
+        'qty' => 1,
+        'unit_price' => 100,
+        'discount' => 0,
+        'tax_rate' => 20,
+    ]);
+
+    $quote->refresh();
+
+    $response = post(route('quotes.approve', $quote), [
+        'legal_name' => 'Jane Doe',
+        'accept_terms' => '1',
+    ]);
+
+    $response->assertSessionHasNoErrors();
+
+    $quote->refresh();
+    expect($quote->status)->toBe('approved');
+    expect($quote->meta['signature']['name'])->toBe('Jane Doe');
+    expect($quote->meta['signature']['ip_hash'])
+        ->toBe(hash('sha256', '127.0.0.1'));
+    expect($quote->meta['signature']['signed_at'])->not->toBeNull();
+
+    $invoice = Invoice::first();
+    expect($invoice)->not->toBeNull();
+    expect($invoice->number)->toBe('INV-' . $quote->number);
+    expect($invoice->grand_total)->toBe($quote->grand_total);
+});
+


### PR DESCRIPTION
## Summary
- Ensure quote totals are recalculated before e-sign approval
- Provide QuoteItemFactory for generating quote line items
- Add feature tests for quote totals and e-sign invoice conversion

## Testing
- ⚠️ `composer test` *(failed: vendor/autoload.php missing; composer install/update blocked)*

------
https://chatgpt.com/codex/tasks/task_e_689f670497908332b5562ad5cc70d948