### PR TITLE
Implement lead kanban board with meeting URLs and activity logging

### DIFF
--- a/app/Models/Lead.php
+++ b/app/Models/Lead.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class Lead extends Model
 {
@@ -24,6 +25,11 @@ class Lead extends Model
     public function quotes()
     {
         return $this->hasMany(Quote::class);
+    }
+
+    public function meetings(): HasMany
+    {
+        return $this->hasMany(Meeting::class);
     }
  
     protected $fillable = [

--- a/app/Models/Meeting.php
+++ b/app/Models/Meeting.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Support\Str;
 use App\Models\Setting;
 
@@ -20,5 +21,10 @@ class Meeting extends Model
                 $meeting->url = str_replace('{code}', $code, $template);
             }
         });
+    }
+
+    public function lead(): BelongsTo
+    {
+        return $this->belongsTo(Lead::class);
     }
 }

--- a/app/Models/PipelineStage.php
+++ b/app/Models/PipelineStage.php
@@ -4,10 +4,20 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use App\Models\Lead;
 
 class PipelineStage extends Model
 {
     use HasFactory;
 
     protected $guarded = [];
+
+    /**
+     * Leads that currently reside in this stage.
+     */
+    public function leads(): HasMany
+    {
+        return $this->hasMany(Lead::class);
+    }
 }

--- a/app/Repositories/LeadRepository.php
+++ b/app/Repositories/LeadRepository.php
@@ -6,10 +6,8 @@ use App\Models\Lead;
 
 class LeadRepository extends BaseRepository
 {
-    protected array  = [];
-
-    public function __construct(Lead )
+    public function __construct(Lead $model)
     {
-        parent::__construct();
+        parent::__construct($model);
     }
 }

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -2,7 +2,7 @@
 
 namespace Database\Seeders;
 
-use App\Models\{BlogPost, Invoice, Lead, License, Order, Page, PipelineStage, Product, Project, Quote, ReleaseChannel, Ticket, User, Version};
+use App\Models\{BlogPost, Invoice, Lead, License, Order, Page, PipelineStage, Product, Project, Quote, ReleaseChannel, Ticket, User, Version, Setting};
 use Illuminate\Database\Seeder;
 
 class DatabaseSeeder extends Seeder
@@ -19,6 +19,12 @@ class DatabaseSeeder extends Seeder
             'role' => 'ADMIN',
         ]);
         $users->push($admin);
+
+        Setting::firstOrCreate([
+            'key' => 'google_meet_template',
+        ], [
+            'value' => 'https://meet.google.com/{code}',
+        ]);
 
         Page::factory(5)->create();
         BlogPost::factory(5)->for($users->random(), 'author')->create();

--- a/resources/views/admin/leads/index.blade.php
+++ b/resources/views/admin/leads/index.blade.php
@@ -1,0 +1,43 @@
+@extends('layouts.admin')
+
+@section('admin-content')
+<div class="flex space-x-4 overflow-x-auto" x-data="kanban()">
+    @foreach($stages as $stage)
+        <div class="w-64 flex-shrink-0" data-stage-id="{{ $stage->id }}">
+            <h2 class="font-semibold mb-2">{{ $stage->name }}</h2>
+            <div class="space-y-2 min-h-[100px] bg-gray-100 p-2 rounded" x-sortable x-on:sort="reorder($event)">
+                @foreach($stage->leads as $lead)
+                    <div class="p-2 bg-white rounded shadow" x-sortable-item data-id="{{ $lead->id }}">
+                        {{ $lead->name }}
+                    </div>
+                @endforeach
+            </div>
+        </div>
+    @endforeach
+</div>
+
+<script>
+function kanban() {
+    return {
+        reorder(event) {
+            const leadId = event.item.dataset.id;
+            const stageId = event.to.closest('[data-stage-id]').getAttribute('data-stage-id');
+            fetch(`/admin/leads/${leadId}/move`, {
+                method: 'POST',
+                headers: {
+                    'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').getAttribute('content'),
+                    'Content-Type': 'application/json'
+                },
+                body: JSON.stringify({ stage_id: stageId })
+            })
+            .then(r => r.json())
+            .then(data => {
+                if (data.meeting_url) {
+                    console.log('Meeting URL:', data.meeting_url);
+                }
+            });
+        }
+    }
+}
+</script>
+@endsection

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -16,6 +16,7 @@
 
     <!-- Scripts -->
     @vite(['resources/css/app.css', 'resources/js/app.js'])
+    <script defer src="https://cdn.jsdelivr.net/npm/@alpinejs/sortable@3.x.x/dist/cdn.min.js"></script>
 
     <style>
         .sidebar-transition {

--- a/routes/admin.php
+++ b/routes/admin.php
@@ -10,6 +10,7 @@ use App\Http\Controllers\Admin\CaseStudyController;
 use App\Http\Controllers\Admin\TestimonialController;
 use App\Http\Controllers\Admin\TeamMemberController;
 use App\Http\Controllers\Admin\MediaController;
+use App\Http\Controllers\Admin\LeadController;
 
 Route::get('/', function () {
     return 'Admin Dashboard';
@@ -26,4 +27,7 @@ Route::resources([
     'team-members' => TeamMemberController::class,
     'media' => MediaController::class,
 ]);
+
+Route::get('leads', [LeadController::class, 'index'])->name('leads.index');
+Route::post('leads/{lead}/move', [LeadController::class, 'moveStage'])->name('leads.move');
 


### PR DESCRIPTION
## Summary
- add Alpine Sortable powered kanban board for lead stages
- log lead stage changes and auto-create Google Meet meeting URLs
- seed default Google Meet template and expose stage lead relationships

## Testing
- `php artisan test` *(fails: Failed opening required 'vendor/autoload.php')*
- `composer install` *(fails: Required package ... not present in the lock file)*

------
https://chatgpt.com/codex/tasks/task_e_689f6748477c8332ab05ba9bcd611fa4