### PR TITLE
feat: add two-factor authentication

### DIFF
--- a/app/Http/Controllers/Auth/AuthenticatedSessionController.php
+++ b/app/Http/Controllers/Auth/AuthenticatedSessionController.php
@@ -26,6 +26,17 @@ class AuthenticatedSessionController extends Controller
     {
         $request->authenticate();
 
+        $user = Auth::user();
+
+        if ($user && $user->two_factor_secret) {
+            Auth::logout();
+
+            $request->session()->put('login.id', $user->id);
+            $request->session()->put('login.remember', $request->boolean('remember'));
+
+            return redirect()->route('two-factor.login');
+        }
+
         $request->session()->regenerate();
 
         return redirect()->intended(route('dashboard', absolute: false));

--- a/app/Http/Controllers/Auth/TwoFactorAuthenticationController.php
+++ b/app/Http/Controllers/Auth/TwoFactorAuthenticationController.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Http\Controllers\Auth;
+
+use App\Http\Controllers\Controller;
+use App\Services\TwoFactorService;
+use Illuminate\Http\Request;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\View\View;
+
+class TwoFactorAuthenticationController extends Controller
+{
+    public function create(Request $request, TwoFactorService $service): View
+    {
+        $user = $request->user();
+
+        if ($user->two_factor_secret) {
+            return view('auth.two-factor-settings');
+        }
+
+        $secret = $service->generateSecret();
+        $qr = $service->getQRCodeUrl(config('app.name'), $user->email, $secret);
+
+        return view('auth.two-factor-settings', [
+            'secret' => $secret,
+            'qrCode' => $qr,
+        ]);
+    }
+
+    public function store(Request $request, TwoFactorService $service): RedirectResponse
+    {
+        $request->validate([
+            'secret' => ['required', 'string'],
+            'code' => ['required', 'string'],
+        ]);
+
+        if (! $service->verify($request->string('secret'), $request->string('code'))) {
+            return back()->withErrors(['code' => __('Invalid authentication code.')]);
+        }
+
+        $request->user()->forceFill([
+            'two_factor_secret' => $request->string('secret'),
+        ])->save();
+
+        return redirect()->route('dashboard', [], false)->with('status', 'two-factor-enabled');
+    }
+
+    public function destroy(Request $request): RedirectResponse
+    {
+        $request->user()->forceFill([
+            'two_factor_secret' => null,
+        ])->save();
+
+        return redirect()->route('dashboard', [], false)->with('status', 'two-factor-disabled');
+    }
+}

--- a/app/Http/Controllers/Auth/TwoFactorChallengeController.php
+++ b/app/Http/Controllers/Auth/TwoFactorChallengeController.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Http\Controllers\Auth;
+
+use App\Http\Controllers\Controller;
+use App\Models\User;
+use App\Services\TwoFactorService;
+use Illuminate\Http\Request;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\View\View;
+
+class TwoFactorChallengeController extends Controller
+{
+    public function create(): View
+    {
+        return view('auth.two-factor-challenge');
+    }
+
+    public function store(Request $request, TwoFactorService $service): RedirectResponse
+    {
+        $request->validate([
+            'code' => ['required', 'string'],
+        ]);
+
+        $userId = $request->session()->pull('login.id');
+        $remember = $request->session()->pull('login.remember', false);
+        $user = User::find($userId);
+
+        if (! $user || ! $user->two_factor_secret || ! $service->verify($user->two_factor_secret, $request->string('code'))) {
+            return back()->withErrors(['code' => __('The provided authentication code is invalid.')]);
+        }
+
+        Auth::login($user, $remember);
+        $request->session()->regenerate();
+
+        return redirect()->intended(route('dashboard', [], false));
+    }
+}

--- a/app/Http/Middleware/EnsureTwoFactorEnabled.php
+++ b/app/Http/Middleware/EnsureTwoFactorEnabled.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class EnsureTwoFactorEnabled
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        $user = $request->user();
+
+        if (! $user || ! $user->two_factor_secret) {
+            return redirect()->route('two-factor.setup');
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -2,12 +2,12 @@
 
 namespace App\Models;
 
-// use Illuminate\Contracts\Auth\MustVerifyEmail;
+use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 
-class User extends Authenticatable
+class User extends Authenticatable implements MustVerifyEmail
 {
     /** @use HasFactory<\Database\Factories\UserFactory> */
     use HasFactory, Notifiable;
@@ -32,6 +32,7 @@ class User extends Authenticatable
     protected $hidden = [
         'password',
         'remember_token',
+        'two_factor_secret',
     ];
 
     /**

--- a/app/Services/TwoFactorService.php
+++ b/app/Services/TwoFactorService.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace App\Services;
+
+class TwoFactorService
+{
+    public function generateSecret(int $length = 16): string
+    {
+        return $this->base32Encode(random_bytes($length));
+    }
+
+    public function getQRCodeUrl(string $company, string $email, string $secret): string
+    {
+        $otpauth = sprintf('otpauth://totp/%s:%s?secret=%s&issuer=%s', rawurlencode($company), rawurlencode($email), $secret, rawurlencode($company));
+        return 'https://chart.googleapis.com/chart?chs=200x200&cht=qr&chl=' . urlencode($otpauth);
+    }
+
+    public function verify(string $secret, string $code, int $window = 1): bool
+    {
+        $timeSlice = (int) floor(time() / 30);
+        for ($i = -$window; $i <= $window; $i++) {
+            if (hash_equals($this->calculateCode($secret, $timeSlice + $i), $code)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    protected function calculateCode(string $secret, int $timeSlice): string
+    {
+        $secretKey = $this->base32Decode($secret);
+        $time = pack('N*', 0) . pack('N*', $timeSlice);
+        $hash = hash_hmac('sha1', $time, $secretKey, true);
+        $offset = ord(substr($hash, -1)) & 0x0F;
+        $truncatedHash = substr($hash, $offset, 4);
+        $value = unpack('N', $truncatedHash)[1] & 0x7FFFFFFF;
+        $mod = $value % 1000000;
+        return str_pad((string) $mod, 6, '0', STR_PAD_LEFT);
+    }
+
+    protected function base32Encode(string $data): string
+    {
+        $alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567';
+        $binary = '';
+        foreach (str_split($data) as $char) {
+            $binary .= str_pad(decbin(ord($char)), 8, '0', STR_PAD_LEFT);
+        }
+        $output = '';
+        foreach (str_split($binary, 5) as $segment) {
+            if (strlen($segment) < 5) {
+                $segment = str_pad($segment, 5, '0');
+            }
+            $output .= $alphabet[bindec($segment)];
+        }
+        return $output;
+    }
+
+    protected function base32Decode(string $secret): string
+    {
+        $alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567';
+        $secret = strtoupper($secret);
+        $bits = '';
+        foreach (str_split($secret) as $char) {
+            $pos = strpos($alphabet, $char);
+            if ($pos !== false) {
+                $bits .= str_pad(decbin($pos), 5, '0', STR_PAD_LEFT);
+            }
+        }
+        $binary = '';
+        foreach (str_split($bits, 8) as $byte) {
+            if (strlen($byte) === 8) {
+                $binary .= chr(bindec($byte));
+            }
+        }
+        return $binary;
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -21,6 +21,9 @@ return Application::configure(basePath: dirname(__DIR__))
     )
     ->withMiddleware(function (Middleware $middleware): void {
         $middleware->append(App\Http\Middleware\CanonicalRedirect::class);
+        $middleware->alias([
+            'twofactor' => App\Http\Middleware\EnsureTwoFactorEnabled::class,
+        ]);
     })
     ->withExceptions(function (Exceptions $exceptions): void {
         //

--- a/database/migrations/2025_08_19_000000_add_two_factor_secret_to_users_table.php
+++ b/database/migrations/2025_08_19_000000_add_two_factor_secret_to_users_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('two_factor_secret')->nullable()->after('remember_token');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('two_factor_secret');
+        });
+    }
+};

--- a/resources/views/auth/two-factor-challenge.blade.php
+++ b/resources/views/auth/two-factor-challenge.blade.php
@@ -1,0 +1,15 @@
+<x-guest-layout>
+    <form method="POST" action="{{ route('two-factor.login') }}">
+        @csrf
+        <div>
+            <x-input-label for="code" :value="__('Authentication Code')" />
+            <x-text-input id="code" class="block mt-1 w-full" type="text" name="code" autofocus required />
+            <x-input-error :messages="$errors->get('code')" class="mt-2" />
+        </div>
+        <div class="flex items-center justify-end mt-4">
+            <x-primary-button>
+                {{ __('Verify') }}
+            </x-primary-button>
+        </div>
+    </form>
+</x-guest-layout>

--- a/resources/views/auth/two-factor-settings.blade.php
+++ b/resources/views/auth/two-factor-settings.blade.php
@@ -1,0 +1,32 @@
+<x-app-layout>
+    <div class="max-w-xl mx-auto py-8">
+        @if (Auth::user()->two_factor_secret)
+            <p class="mb-4">{{ __('Two-factor authentication is enabled.') }}</p>
+            <form method="POST" action="{{ route('two-factor.disable') }}">
+                @csrf
+                @method('DELETE')
+                <x-primary-button>{{ __('Disable') }}</x-primary-button>
+            </form>
+        @else
+            <p class="mb-4">{{ __('Scan the QR code using your authenticator app or enter the code below.') }}</p>
+            <div class="mb-4">
+                @isset($qrCode)
+                    <img src="{{ $qrCode }}" alt="QR Code" class="mb-4" />
+                @endisset
+                <p class="font-mono">{{ $secret }}</p>
+            </div>
+            <form method="POST" action="{{ route('two-factor.enable') }}">
+                @csrf
+                <input type="hidden" name="secret" value="{{ $secret }}">
+                <div>
+                    <x-input-label for="code" :value="__('Code')" />
+                    <x-text-input id="code" class="block mt-1 w-full" type="text" name="code" autofocus required />
+                    <x-input-error :messages="$errors->get('code')" class="mt-2" />
+                </div>
+                <div class="flex items-center justify-end mt-4">
+                    <x-primary-button>{{ __('Enable') }}</x-primary-button>
+                </div>
+            </form>
+        @endif
+    </div>
+</x-app-layout>

--- a/routes/auth.php
+++ b/routes/auth.php
@@ -9,6 +9,8 @@ use App\Http\Controllers\Auth\PasswordController;
 use App\Http\Controllers\Auth\PasswordResetLinkController;
 use App\Http\Controllers\Auth\RegisteredUserController;
 use App\Http\Controllers\Auth\VerifyEmailController;
+use App\Http\Controllers\Auth\TwoFactorAuthenticationController;
+use App\Http\Controllers\Auth\TwoFactorChallengeController;
 use Illuminate\Support\Facades\Route;
 
 Route::middleware('guest')->group(function () {
@@ -56,4 +58,15 @@ Route::middleware('auth')->group(function () {
 
     Route::post('logout', [AuthenticatedSessionController::class, 'destroy'])
         ->name('logout');
+
+    Route::get('two-factor', [TwoFactorAuthenticationController::class, 'create'])
+        ->name('two-factor.setup');
+    Route::post('two-factor', [TwoFactorAuthenticationController::class, 'store'])
+        ->name('two-factor.enable');
+    Route::delete('two-factor', [TwoFactorAuthenticationController::class, 'destroy'])
+        ->name('two-factor.disable');
 });
+
+Route::get('two-factor-challenge', [TwoFactorChallengeController::class, 'create'])
+    ->name('two-factor.login');
+Route::post('two-factor-challenge', [TwoFactorChallengeController::class, 'store']);

--- a/routes/portal.php
+++ b/routes/portal.php
@@ -3,10 +3,12 @@
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\Portal\QuoteController;
 
-Route::get('/', function () {
-    return 'Client Portal';
-});
+Route::middleware(['auth', 'verified', 'twofactor'])->group(function () {
+    Route::get('/', function () {
+        return 'Client Portal';
+    });
 
-Route::post('quotes/{quote}/approve', [QuoteController::class, 'approve'])
-    ->name('quotes.approve');
+    Route::post('quotes/{quote}/approve', [QuoteController::class, 'approve'])
+        ->name('quotes.approve');
+});
 


### PR DESCRIPTION
## Summary
- add custom TOTP two-factor service and controllers for setup/challenge
- require verified and 2FA-secured sessions for portal routes
- implement email verification on User model

## Testing
- `php artisan test` *(fails: Failed opening required '/workspace/PERFEXDEV-360/vendor/autoload.php')*

------
https://chatgpt.com/codex/tasks/task_e_689f6b6d16348332abb25b33ba0283c0