### PR TITLE
Implement license portal with secure downloads and order views

### DIFF
--- a/app/Http/Controllers/Portal/LicenseController.php
+++ b/app/Http/Controllers/Portal/LicenseController.php
@@ -4,63 +4,97 @@ namespace App\Http\Controllers\Portal;
 
 use App\Http\Controllers\Controller;
 use App\Models\License;
-use Illuminate\Http\Request;
+use App\Models\Release;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Facades\URL;
+use Illuminate\Support\Str;
 
 class LicenseController extends Controller
 {
     /**
-     * Display a listing of the resource.
+     * Display a listing of the user's licenses.
      */
     public function index()
     {
-        //
+        $licenses = auth()->user()
+            ->licenses()
+            ->with('product')
+            ->latest()
+            ->get();
+
+        return view('portal.licenses.index', compact('licenses'));
     }
 
     /**
-     * Show the form for creating a new resource.
-     */
-    public function create()
-    {
-        //
-    }
-
-    /**
-     * Store a newly created resource in storage.
-     */
-    public function store(Request $request)
-    {
-        //
-    }
-
-    /**
-     * Display the specified resource.
+     * Display the specified license details.
      */
     public function show(License $license)
     {
-        //
+        abort_if($license->user_id !== auth()->id(), 403);
+
+        $license->load(['product', 'activationHistory']);
+
+        $releases = Release::where('product_id', $license->product_id)
+            ->where('is_published', true)
+            ->with('fileArtifacts')
+            ->latest('released_at')
+            ->get();
+
+        return view('portal.licenses.show', [
+            'license' => $license,
+            'releases' => $releases,
+        ]);
     }
 
     /**
-     * Show the form for editing the specified resource.
+     * Rotate the license key.
      */
-    public function edit(License $license)
+    public function rotate(License $license): RedirectResponse
     {
-        //
+        abort_if($license->user_id !== auth()->id(), 403);
+
+        $license->update([
+            'license_key' => Str::uuid()->toString(),
+        ]);
+
+        $license->events()->create(['event' => 'rotated']);
+
+        return back()->with('status', 'License key rotated.');
     }
 
     /**
-     * Update the specified resource in storage.
+     * Download a release for this license using a signed URL.
      */
-    public function update(Request $request, License $license)
+    public function download(License $license, Release $release)
     {
-        //
+        abort_if($license->user_id !== auth()->id(), 403);
+        abort_if($release->product_id !== $license->product_id, 403);
+
+        if ($license->is_revoked ||
+            ($license->update_window_ends_at && now()->greaterThan($license->update_window_ends_at))) {
+            abort(403, 'License not eligible');
+        }
+
+        $artifact = $release->fileArtifacts()->firstOrFail();
+
+        $url = Storage::disk('s3')->temporaryUrl(
+            $artifact->path,
+            now()->addMinutes(10)
+        );
+
+        return redirect($url);
     }
 
     /**
-     * Remove the specified resource from storage.
+     * Generate a temporary signed download URL for a release.
      */
-    public function destroy(License $license)
+    public function signedDownloadUrl(License $license, Release $release): string
     {
-        //
+        return URL::temporarySignedRoute(
+            'licenses.download',
+            now()->addMinutes(5),
+            ['license' => $license->id, 'release' => $release->id]
+        );
     }
 }

--- a/app/Http/Controllers/Portal/PurchaseController.php
+++ b/app/Http/Controllers/Portal/PurchaseController.php
@@ -9,58 +9,28 @@ use Illuminate\Http\Request;
 class PurchaseController extends Controller
 {
     /**
-     * Display a listing of the resource.
+     * Display a listing of the user's orders.
      */
     public function index()
     {
-        //
+        $orders = auth()->user()
+            ->orders()
+            ->with('license.product')
+            ->latest()
+            ->get();
+
+        return view('portal.purchases.index', compact('orders'));
     }
 
     /**
-     * Show the form for creating a new resource.
-     */
-    public function create()
-    {
-        //
-    }
-
-    /**
-     * Store a newly created resource in storage.
-     */
-    public function store(Request $request)
-    {
-        //
-    }
-
-    /**
-     * Display the specified resource.
+     * Display the specified order.
      */
     public function show(Order $order)
     {
-        //
-    }
+        abort_if($order->user_id !== auth()->id(), 403);
 
-    /**
-     * Show the form for editing the specified resource.
-     */
-    public function edit(Order $order)
-    {
-        //
-    }
+        $order->load(['license.product', 'invoices']);
 
-    /**
-     * Update the specified resource in storage.
-     */
-    public function update(Request $request, Order $order)
-    {
-        //
-    }
-
-    /**
-     * Remove the specified resource from storage.
-     */
-    public function destroy(Order $order)
-    {
-        //
+        return view('portal.purchases.show', compact('order'));
     }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 
@@ -46,5 +47,21 @@ class User extends Authenticatable implements MustVerifyEmail
             'email_verified_at' => 'datetime',
             'password' => 'hashed',
         ];
+    }
+
+    /**
+     * Licenses owned by the user.
+     */
+    public function licenses(): HasMany
+    {
+        return $this->hasMany(License::class);
+    }
+
+    /**
+     * Orders placed by the user.
+     */
+    public function orders(): HasMany
+    {
+        return $this->hasMany(Order::class);
     }
 }

--- a/resources/views/portal/licenses/index.blade.php
+++ b/resources/views/portal/licenses/index.blade.php
@@ -1,0 +1,27 @@
+@extends('layouts.portal')
+
+@section('portal-content')
+<div class="p-4">
+    <h1 class="text-2xl font-bold mb-4">Licenses</h1>
+    <table class="min-w-full bg-white dark:bg-gray-800 rounded shadow">
+        <thead>
+            <tr class="text-left">
+                <th class="px-4 py-2">Product</th>
+                <th class="px-4 py-2">License Key</th>
+                <th class="px-4 py-2"></th>
+            </tr>
+        </thead>
+        <tbody>
+            @forelse($licenses as $license)
+                <tr class="border-t border-gray-200 dark:border-gray-700">
+                    <td class="px-4 py-2">{{ $license->product->name }}</td>
+                    <td class="px-4 py-2 font-mono text-sm">{{ $license->license_key }}</td>
+                    <td class="px-4 py-2"><a href="{{ route('licenses.show', $license) }}" class="text-blue-600 hover:underline">Manage</a></td>
+                </tr>
+            @empty
+                <tr><td colspan="3" class="px-4 py-4 text-center">No licenses found.</td></tr>
+            @endforelse
+        </tbody>
+    </table>
+</div>
+@endsection

--- a/resources/views/portal/licenses/show.blade.php
+++ b/resources/views/portal/licenses/show.blade.php
@@ -1,0 +1,57 @@
+@extends('layouts.portal')
+
+@section('portal-content')
+<div class="p-4 space-y-6">
+    <div>
+        <h1 class="text-2xl font-bold mb-2">License Details</h1>
+        <p class="font-mono">{{ $license->license_key }}</p>
+        <form action="{{ route('licenses.rotate', $license) }}" method="POST" class="mt-2">
+            @csrf
+            <button class="px-3 py-1 bg-blue-600 text-white rounded" type="submit">Rotate Key</button>
+        </form>
+    </div>
+
+    <div>
+        <h2 class="text-xl font-semibold mb-2">Available Releases</h2>
+        <ul class="space-y-4">
+            @foreach($releases as $release)
+                @php($artifact = $release->fileArtifacts->first())
+                <li class="p-4 border border-gray-200 dark:border-gray-700 rounded">
+                    <div class="font-medium">Version {{ optional($release->version)->name ?? 'N/A' }}</div>
+                    <div class="prose prose-sm dark:prose-invert mt-2">
+                        @foreach((array)$release->notes as $note)
+                            <p>{{ $note }}</p>
+                        @endforeach
+                    </div>
+                    @if($artifact)
+                        <p class="mt-2 text-sm">Checksum: <span class="font-mono">{{ $artifact->hash }}</span></p>
+                        <a href="{{ URL::temporarySignedRoute('licenses.download', now()->addMinutes(5), ['license' => $license->id, 'release' => $release->id]) }}" class="inline-block mt-2 px-3 py-1 bg-green-600 text-white rounded">Download</a>
+                    @endif
+                </li>
+            @endforeach
+        </ul>
+    </div>
+
+    <div>
+        <h2 class="text-xl font-semibold mb-2">Activation History</h2>
+        <table class="min-w-full bg-white dark:bg-gray-800 rounded shadow">
+            <thead>
+                <tr class="text-left">
+                    <th class="px-4 py-2">Event</th>
+                    <th class="px-4 py-2">Date</th>
+                </tr>
+            </thead>
+            <tbody>
+                @forelse($license->activationHistory as $event)
+                    <tr class="border-t border-gray-200 dark:border-gray-700">
+                        <td class="px-4 py-2">{{ ucfirst($event->event) }}</td>
+                        <td class="px-4 py-2">{{ $event->created_at->toDateTimeString() }}</td>
+                    </tr>
+                @empty
+                    <tr><td colspan="2" class="px-4 py-4 text-center">No events.</td></tr>
+                @endforelse
+            </tbody>
+        </table>
+    </div>
+</div>
+@endsection

--- a/resources/views/portal/purchases/index.blade.php
+++ b/resources/views/portal/purchases/index.blade.php
@@ -1,0 +1,29 @@
+@extends('layouts.portal')
+
+@section('portal-content')
+<div class="p-4">
+    <h1 class="text-2xl font-bold mb-4">Orders</h1>
+    <table class="min-w-full bg-white dark:bg-gray-800 rounded shadow">
+        <thead>
+            <tr class="text-left">
+                <th class="px-4 py-2">ID</th>
+                <th class="px-4 py-2">Product</th>
+                <th class="px-4 py-2">Date</th>
+                <th class="px-4 py-2"></th>
+            </tr>
+        </thead>
+        <tbody>
+            @forelse($orders as $order)
+                <tr class="border-t border-gray-200 dark:border-gray-700">
+                    <td class="px-4 py-2">#{{ $order->id }}</td>
+                    <td class="px-4 py-2">{{ optional($order->license->product)->name }}</td>
+                    <td class="px-4 py-2">{{ $order->created_at->toDateString() }}</td>
+                    <td class="px-4 py-2"><a href="{{ route('purchases.show', $order) }}" class="text-blue-600 hover:underline">View</a></td>
+                </tr>
+            @empty
+                <tr><td colspan="4" class="px-4 py-4 text-center">No orders found.</td></tr>
+            @endforelse
+        </tbody>
+    </table>
+</div>
+@endsection

--- a/resources/views/portal/purchases/show.blade.php
+++ b/resources/views/portal/purchases/show.blade.php
@@ -1,0 +1,26 @@
+@extends('layouts.portal')
+
+@section('portal-content')
+<div class="p-4 space-y-6">
+    <div>
+        <h1 class="text-2xl font-bold mb-2">Order #{{ $order->id }}</h1>
+        <p class="text-sm text-gray-500">Placed {{ $order->created_at->toDayDateTimeString() }}</p>
+    </div>
+
+    <div>
+        <h2 class="text-xl font-semibold mb-2">Product</h2>
+        <p>{{ optional($order->license->product)->name }}</p>
+    </div>
+
+    <div>
+        <h2 class="text-xl font-semibold mb-2">Invoices</h2>
+        <ul class="list-disc pl-4">
+            @forelse($order->invoices as $invoice)
+                <li><span class="font-mono">{{ $invoice->number ?? 'N/A' }}</span> - {{ $invoice->status ?? 'Pending' }}</li>
+            @empty
+                <li>No invoices associated.</li>
+            @endforelse
+        </ul>
+    </div>
+</div>
+@endsection

--- a/routes/portal.php
+++ b/routes/portal.php
@@ -1,6 +1,8 @@
 <?php
 
 use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\Portal\LicenseController;
+use App\Http\Controllers\Portal\PurchaseController;
 use App\Http\Controllers\Portal\QuoteController;
 
 Route::middleware(['auth', 'verified', 'twofactor'])->group(function () {
@@ -10,5 +12,13 @@ Route::middleware(['auth', 'verified', 'twofactor'])->group(function () {
 
     Route::post('quotes/{quote}/approve', [QuoteController::class, 'approve'])
         ->name('quotes.approve');
+
+    Route::resource('purchases', PurchaseController::class)->only(['index', 'show']);
+    Route::resource('licenses', LicenseController::class)->only(['index', 'show']);
+    Route::post('licenses/{license}/rotate', [LicenseController::class, 'rotate'])
+        ->name('licenses.rotate');
+    Route::get('licenses/{license}/download/{release}', [LicenseController::class, 'download'])
+        ->name('licenses.download')
+        ->middleware('signed');
 });
 


### PR DESCRIPTION
## Summary
- Add user relations for licenses and orders
- Implement portal controllers and routes for order listing and license management
- Allow license key rotation, show activation history and signed release downloads with checksum

## Testing
- `composer test` *(fails: vendor/autoload.php missing)*

------
https://chatgpt.com/codex/tasks/task_e_689f6d33eb14833284fe83d6bee62f2e