### PR TITLE
Implement RFQ lead mapping and service matcher

### DIFF
--- a/app/Http/Controllers/Frontend/RfqController.php
+++ b/app/Http/Controllers/Frontend/RfqController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Frontend;
 
 use App\Http\Controllers\Controller;
 use App\Models\LeadAttachment;
+use App\Models\QuoteItem;
 use App\Models\Service;
 use App\Models\ServiceRequest;
 use Illuminate\Http\RedirectResponse;
@@ -30,6 +31,43 @@ class RfqController extends Controller
         ]);
 
         $serviceRequest->refresh();
+
+        $lead = $serviceRequest->lead;
+        $lead->update([
+            'notes' => $data['notes'] ?? null,
+            'tech_stack' => collect($serviceRequest->selected_options ?? [])->keys()->implode(','),
+        ]);
+
+        $quote = $lead->quotes()->first();
+
+        foreach ($service->options()->whereIn('slug', array_keys($serviceRequest->selected_options ?? []))->get() as $option) {
+            $value = $serviceRequest->selected_options[$option->slug] ?? null;
+            if ($option->type === 'boolean' && ! in_array($value, [true, 1, '1', 'on'], true)) {
+                continue;
+            }
+
+            $qty = 1;
+            $unitPrice = $option->price_delta;
+            $description = null;
+
+            if ($option->type === 'number' && is_numeric($value)) {
+                $qty = (int) $value;
+            } elseif ($option->type === 'select') {
+                $choice = data_get($option->config, 'choices.' . $value);
+                if ($choice) {
+                    $unitPrice = $choice['price_delta'] ?? $unitPrice;
+                    $description = $choice['label'] ?? $value;
+                }
+            }
+
+            QuoteItem::create([
+                'quote_id' => $quote->id,
+                'title' => $option->name,
+                'description' => $description,
+                'qty' => $qty,
+                'unit_price' => $unitPrice,
+            ]);
+        }
 
         if ($request->hasFile('files')) {
             foreach ($request->file('files') as $file) {

--- a/app/Models/Lead.php
+++ b/app/Models/Lead.php
@@ -4,6 +4,8 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Support\Collection;
 
 class Lead extends Model
 {
@@ -24,6 +26,23 @@ class Lead extends Model
     public function quotes()
     {
         return $this->hasMany(Quote::class);
+    }
+
+    public function serviceRequests(): HasMany
+    {
+        return $this->hasMany(ServiceRequest::class);
+    }
+
+    public function tags(): Collection
+    {
+        $tags = collect(explode(',', (string) $this->tech_stack))
+            ->map(fn ($tag) => trim(strtolower($tag)))
+            ->filter();
+
+        $optionTags = $this->serviceRequests
+            ->flatMap(fn ($request) => array_keys($request->selected_options ?? []));
+
+        return $tags->merge($optionTags)->unique();
     }
  
     protected $fillable = [

--- a/app/Services/ServiceMatcher.php
+++ b/app/Services/ServiceMatcher.php
@@ -13,9 +13,8 @@ class ServiceMatcher
      */
     public function suggestForLead(Lead $lead): Collection
     {
-        $leadTags = collect(explode(',', (string) $lead->tech_stack))
-            ->map(fn ($tag) => trim(strtolower($tag)))
-            ->filter();
+        $lead->loadMissing('serviceRequests');
+        $leadTags = $lead->tags();
 
         return Service::with('options')
             ->get()

--- a/tests/Feature/RfqControllerTest.php
+++ b/tests/Feature/RfqControllerTest.php
@@ -1,0 +1,51 @@
+<?php
+
+use App\Models\PipelineStage;
+use App\Models\Service;
+use App\Models\ServiceRequest;
+use App\Models\LeadAttachment;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+
+it('creates lead and draft quote from rfq', function () {
+    Storage::fake('local');
+
+    PipelineStage::factory()->create(['order' => 1]);
+
+    $service = Service::create([
+        'name' => 'Customization',
+        'slug' => 'customization',
+    ]);
+
+    $option = $service->options()->create([
+        'name' => 'Integration',
+        'slug' => 'integration',
+        'type' => 'boolean',
+        'price_delta' => 1000,
+    ]);
+
+    $file = UploadedFile::fake()->create('spec.pdf', 20, 'application/pdf');
+
+    $response = $this->post(route('rfq.store', $service), [
+        'options' => [
+            $option->slug => '1',
+        ],
+        'notes' => 'Need integration',
+        'files' => [$file],
+    ]);
+
+    $response->assertRedirect();
+
+    $serviceRequest = ServiceRequest::first();
+    $lead = $serviceRequest->lead;
+    $quote = $lead->quotes()->first();
+
+    expect($lead->notes)->toBe('Need integration');
+    expect($lead->tech_stack)->toContain('integration');
+    expect($quote->status)->toBe('draft');
+    expect($quote->items)->toHaveCount(1);
+    expect($quote->items->first()->title)->toBe('Integration');
+
+    Storage::disk('local')->assertExists(LeadAttachment::first()->path);
+});
+

--- a/tests/Feature/ServiceMatcherTest.php
+++ b/tests/Feature/ServiceMatcherTest.php
@@ -1,0 +1,37 @@
+<?php
+
+use App\Models\Lead;
+use App\Models\PipelineStage;
+use App\Models\Service;
+use App\Services\ServiceMatcher;
+
+it('suggests services based on lead tags', function () {
+    PipelineStage::factory()->create(['order' => 1]);
+
+    $service = Service::create([
+        'name' => 'Customization',
+        'slug' => 'customization',
+        'category' => 'web',
+    ]);
+
+    $service->options()->create([
+        'name' => 'Laravel',
+        'slug' => 'laravel',
+        'type' => 'boolean',
+        'price_delta' => 0,
+    ]);
+
+    $lead = Lead::create([
+        'name' => 'Test Lead',
+        'source' => 'test',
+        'pipeline_stage_id' => 1,
+        'tech_stack' => 'laravel,vue',
+    ]);
+
+    $matcher = new ServiceMatcher();
+
+    $suggestions = $matcher->suggestForLead($lead);
+
+    expect($suggestions->pluck('id'))->toContain($service->id);
+});
+


### PR DESCRIPTION
## Summary
- map RFQ submissions into leads with draft quotes and line items
- aggregate lead tags from selected options and match services heuristically
- cover RFQ flow and service suggestions with feature tests

## Testing
- `./vendor/bin/pint` *(fails: No such file or directory)*
- `composer install` *(fails: Required package not present in lock file)*
- `composer update` *(fails: curl error 56)*
- `php artisan test` *(fails: vendor/autoload.php missing)*

------
https://chatgpt.com/codex/tasks/task_e_689f68299d98833280ddece2ad99e3e9