### PR TITLE
Add quote rejection and invoice payment flow

### DIFF
--- a/app/Http/Controllers/Portal/InvoiceController.php
+++ b/app/Http/Controllers/Portal/InvoiceController.php
@@ -4,63 +4,45 @@ namespace App\Http\Controllers\Portal;
 
 use App\Http\Controllers\Controller;
 use App\Models\Invoice;
+use App\Services\FlowService;
+use Barryvdh\DomPDF\Facade\Pdf;
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 
 class InvoiceController extends Controller
 {
     /**
-     * Display a listing of the resource.
-     */
-    public function index()
-    {
-        //
-    }
-
-    /**
-     * Show the form for creating a new resource.
-     */
-    public function create()
-    {
-        //
-    }
-
-    /**
-     * Store a newly created resource in storage.
-     */
-    public function store(Request $request)
-    {
-        //
-    }
-
-    /**
-     * Display the specified resource.
+     * Display the specified invoice.
      */
     public function show(Invoice $invoice)
     {
-        //
+        return view('portal.invoices.show', compact('invoice'));
     }
 
     /**
-     * Show the form for editing the specified resource.
+     * Record a payment for the invoice.
      */
-    public function edit(Invoice $invoice)
+    public function pay(Request $request, Invoice $invoice, FlowService $flow): RedirectResponse
     {
-        //
+        $validated = $request->validate([
+            'amount' => ['required', 'numeric', 'min:0'],
+        ]);
+
+        $flow->recordPayment($invoice, (float) $validated['amount']);
+
+        return back()->with('status', 'Invoice paid.');
     }
 
     /**
-     * Update the specified resource in storage.
+     * Download a receipt PDF for the invoice.
      */
-    public function update(Request $request, Invoice $invoice)
+    public function receipt(Invoice $invoice)
     {
-        //
-    }
+        $pdf = Pdf::loadView('invoices.receipt', [
+            'invoice' => $invoice,
+        ]);
 
-    /**
-     * Remove the specified resource from storage.
-     */
-    public function destroy(Invoice $invoice)
-    {
-        //
+        return $pdf->download('invoice-' . $invoice->number . '.pdf');
     }
 }
+

--- a/app/Http/Controllers/Portal/QuoteController.php
+++ b/app/Http/Controllers/Portal/QuoteController.php
@@ -76,4 +76,16 @@ class QuoteController extends Controller
 
         return back()->with('status', 'Quote approved.');
     }
+
+    public function reject(Request $request, Quote $quote): RedirectResponse
+    {
+        $validated = $request->validate([
+            'legal_name' => ['required', 'string'],
+            'accept_terms' => ['accepted'],
+        ]);
+
+        $quote->reject($validated['legal_name'], $request->ip());
+
+        return back()->with('status', 'Quote rejected.');
+    }
 }

--- a/app/Mail/PaymentReceipt.php
+++ b/app/Mail/PaymentReceipt.php
@@ -18,15 +18,20 @@ class PaymentReceipt extends Mailable
 
     public function build()
     {
-        $pdf = Pdf::loadView('invoices.receipt', [
-            'invoice' => $this->payment->invoice,
-            'payment' => $this->payment,
-        ]);
-
-        return $this->subject('Payment Receipt')
+        $mail = $this->subject('Payment Receipt')
             ->view('emails.payment-receipt', [
                 'payment' => $this->payment,
-            ])
-            ->attachData($pdf->output(), 'invoice-'.$this->payment->invoice->number.'.pdf');
+            ]);
+
+        if (class_exists(Pdf::class)) {
+            $pdf = Pdf::loadView('invoices.receipt', [
+                'invoice' => $this->payment->invoice,
+                'payment' => $this->payment,
+            ]);
+
+            $mail->attachData($pdf->output(), 'invoice-' . $this->payment->invoice->number . '.pdf');
+        }
+
+        return $mail;
     }
 }

--- a/resources/views/portal/invoices/show.blade.php
+++ b/resources/views/portal/invoices/show.blade.php
@@ -1,0 +1,24 @@
+@extends('layouts.portal')
+
+@section('portal-content')
+<div class="p-4 space-y-4">
+    <h1 class="text-2xl font-bold">Invoice #{{ $invoice->number }}</h1>
+    <p>Status: {{ ucfirst($invoice->status ?? 'pending') }}</p>
+    <p>Total: {{ number_format($invoice->grand_total, 2) }} USD</p>
+
+    @if(session('status'))
+        <div class="text-green-600">{{ session('status') }}</div>
+    @endif
+
+    @if(($invoice->status ?? '') !== 'paid')
+        <form method="POST" action="{{ route('portal.invoices.pay', $invoice) }}" class="mt-4">
+            @csrf
+            <input type="hidden" name="amount" value="{{ $invoice->grand_total }}">
+            <button type="submit" class="px-4 py-2 bg-blue-600 text-white rounded">Pay Now</button>
+        </form>
+    @else
+        <a href="{{ route('portal.invoices.receipt', $invoice) }}" class="inline-block px-4 py-2 bg-green-600 text-white rounded">Download Receipt</a>
+    @endif
+</div>
+@endsection
+

--- a/routes/portal.php
+++ b/routes/portal.php
@@ -4,6 +4,7 @@ use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\Portal\LicenseController;
 use App\Http\Controllers\Portal\PurchaseController;
 use App\Http\Controllers\Portal\QuoteController;
+use App\Http\Controllers\Portal\InvoiceController;
 
 Route::middleware(['auth', 'verified', 'twofactor'])->group(function () {
     Route::get('/', function () {
@@ -12,6 +13,14 @@ Route::middleware(['auth', 'verified', 'twofactor'])->group(function () {
 
     Route::post('quotes/{quote}/approve', [QuoteController::class, 'approve'])
         ->name('quotes.approve');
+    Route::post('quotes/{quote}/reject', [QuoteController::class, 'reject'])
+        ->name('quotes.reject');
+
+    Route::resource('invoices', InvoiceController::class)->only(['show']);
+    Route::post('invoices/{invoice}/pay', [InvoiceController::class, 'pay'])
+        ->name('invoices.pay');
+    Route::get('invoices/{invoice}/receipt', [InvoiceController::class, 'receipt'])
+        ->name('invoices.receipt');
 
     Route::resource('purchases', PurchaseController::class)->only(['index', 'show']);
     Route::resource('licenses', LicenseController::class)->only(['index', 'show']);

--- a/tests/Feature/InvoicePaymentTest.php
+++ b/tests/Feature/InvoicePaymentTest.php
@@ -1,0 +1,26 @@
+<?php
+
+use App\Mail\PaymentReceipt;
+use App\Models\{Invoice, User};
+use Illuminate\Support\Facades\Mail;
+use function Pest\Laravel\post;
+use function Pest\Laravel\actingAs;
+
+it('records a payment and emails a receipt', function () {
+    Mail::fake();
+
+    $invoice = Invoice::factory()->create([
+        'grand_total' => 100,
+        'status' => 'pending',
+    ]);
+
+    actingAs(User::factory()->create(['role' => 'client']));
+
+    post(route('portal.invoices.pay', $invoice), [
+        'amount' => 100,
+    ])->assertSessionHasNoErrors();
+
+    expect($invoice->fresh()->status)->toBe('paid');
+    Mail::assertSent(PaymentReceipt::class);
+});
+


### PR DESCRIPTION
## Summary
- allow clients to reject quotes with an e-signature
- add portal invoice screen with payment and receipt download
- send receipts only when PDF library is available

## Testing
- `composer update` *(fails: CONNECT tunnel failed 403)*
- `composer test` *(fails: vendor/autoload.php missing)*

------
https://chatgpt.com/codex/tasks/task_e_689f6eb17db48332bec5cfa56d3c3378