### PR TITLE
feat: add support tickets and project hub basics

### DIFF
--- a/app/Models/Milestone.php
+++ b/app/Models/Milestone.php
@@ -2,9 +2,17 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class Milestone extends Model
 {
-    //
+    use HasFactory;
+
+    protected $guarded = [];
+
+    public function project()
+    {
+        return $this->belongsTo(Project::class);
+    }
 }

--- a/app/Models/Project.php
+++ b/app/Models/Project.php
@@ -20,4 +20,29 @@ class Project extends Model
     {
         return $this->hasMany(Ticket::class);
     }
+
+    public function milestones()
+    {
+        return $this->hasMany(Milestone::class);
+    }
+
+    public function tasks()
+    {
+        return $this->hasMany(Task::class);
+    }
+
+    public function files()
+    {
+        return $this->hasMany(ProjectFile::class);
+    }
+
+    public function discussions()
+    {
+        return $this->hasMany(ProjectDiscussion::class);
+    }
+
+    public function activities()
+    {
+        return $this->hasMany(ProjectActivity::class);
+    }
 }

--- a/app/Models/ProjectDiscussion.php
+++ b/app/Models/ProjectDiscussion.php
@@ -5,14 +5,14 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
-class ProjectActivity extends Model
+class ProjectDiscussion extends Model
 {
     use HasFactory;
 
     protected $guarded = [];
 
     protected $casts = [
-        'data' => 'array',
+        'attachments' => 'array',
     ];
 
     public function project()

--- a/app/Models/ProjectFile.php
+++ b/app/Models/ProjectFile.php
@@ -2,9 +2,22 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class ProjectFile extends Model
 {
-    //
+    use HasFactory;
+
+    protected $guarded = [];
+
+    public function project()
+    {
+        return $this->belongsTo(Project::class);
+    }
+
+    public function uploadedBy()
+    {
+        return $this->belongsTo(User::class, 'uploaded_by_id');
+    }
 }

--- a/app/Models/Task.php
+++ b/app/Models/Task.php
@@ -2,9 +2,22 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class Task extends Model
 {
-    //
+    use HasFactory;
+
+    protected $guarded = [];
+
+    public function project()
+    {
+        return $this->belongsTo(Project::class);
+    }
+
+    public function assignee()
+    {
+        return $this->belongsTo(User::class, 'assignee_id');
+    }
 }

--- a/app/Models/Ticket.php
+++ b/app/Models/Ticket.php
@@ -2,14 +2,28 @@
 
 namespace App\Models;
 
+use App\Notifications\TicketCreated;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Notification;
 
 class Ticket extends Model
 {
     use HasFactory;
 
     protected $guarded = [];
+
+    protected $casts = [
+        'last_activity_at' => 'datetime',
+    ];
+
+    protected static function booted(): void
+    {
+        static::created(function (Ticket $ticket) {
+            Notification::route('mail', config('mail.from.address', 'support@example.com'))
+                ->notify(new TicketCreated($ticket));
+        });
+    }
 
     public function user()
     {
@@ -19,5 +33,10 @@ class Ticket extends Model
     public function project()
     {
         return $this->belongsTo(Project::class);
+    }
+
+    public function replies()
+    {
+        return $this->hasMany(TicketReply::class);
     }
 }

--- a/app/Models/TicketReply.php
+++ b/app/Models/TicketReply.php
@@ -2,9 +2,31 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class TicketReply extends Model
 {
-    //
+    use HasFactory;
+
+    protected $guarded = [];
+
+    protected $casts = [
+        'attachments' => 'array',
+    ];
+
+    public function ticket()
+    {
+        return $this->belongsTo(Ticket::class);
+    }
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function scopeInternal($query)
+    {
+        return $query->where('is_internal', true);
+    }
 }

--- a/app/Notifications/TicketCreated.php
+++ b/app/Notifications/TicketCreated.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Notifications;
+
+use App\Models\Ticket;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class TicketCreated extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    public function __construct(public Ticket $ticket)
+    {
+    }
+
+    public function via(object $notifiable): array
+    {
+        return ['mail'];
+    }
+
+    public function toMail(object $notifiable): MailMessage
+    {
+        return (new MailMessage)
+            ->subject('New Support Ticket')
+            ->view('emails.ticket_created', [
+                'ticket' => $this->ticket,
+            ]);
+    }
+}

--- a/app/Services/FlowService.php
+++ b/app/Services/FlowService.php
@@ -154,14 +154,25 @@ class FlowService
     /**
      * Record a reply to a ticket and reopen it if necessary.
      */
-    public function replyToTicket(Ticket $ticket, User $user, string $message): TicketReply
-    {
+    public function replyToTicket(
+        Ticket $ticket,
+        User $user,
+        string $body,
+        ?array $attachments = null,
+        bool $internal = false
+    ): TicketReply {
         $reply = $ticket->replies()->create([
             'user_id' => $user->id,
-            'message' => $message,
+            'body' => $body,
+            'attachments' => $attachments,
+            'is_internal' => $internal,
         ]);
 
-        $ticket->status = 'open';
+        if (! $internal) {
+            $ticket->status = 'open';
+        }
+
+        $ticket->last_activity_at = now();
         $ticket->save();
 
         return $reply;
@@ -173,7 +184,6 @@ class FlowService
     public function closeTicket(Ticket $ticket): void
     {
         $ticket->status = 'closed';
-        $ticket->closed_at = now();
         $ticket->save();
     }
 

--- a/database/migrations/2025_08_20_000000_create_project_discussions_table.php
+++ b/database/migrations/2025_08_20_000000_create_project_discussions_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('project_discussions', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('project_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('user_id')->nullable()->constrained()->nullOnDelete();
+            $table->text('body');
+            $table->json('attachments')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('project_discussions');
+    }
+};

--- a/resources/views/emails/ticket_created.blade.php
+++ b/resources/views/emails/ticket_created.blade.php
@@ -1,0 +1,2 @@
+<p>A new support ticket has been created.</p>
+<p>Subject: {{ $ticket->subject }}</p>

--- a/tests/Feature/ProjectHubTest.php
+++ b/tests/Feature/ProjectHubTest.php
@@ -1,0 +1,24 @@
+<?php
+
+use App\Models\{Project, ProjectActivity, ProjectDiscussion, ProjectFile, Task, Milestone, User};
+
+it('associates project resources', function () {
+    $user = User::factory()->create();
+
+    $project = Project::create([
+        'name' => 'Demo',
+        'user_id' => $user->id,
+    ]);
+
+    $project->milestones()->create(['title' => 'Phase 1']);
+    $project->tasks()->create(['title' => 'Initial task']);
+    $project->files()->create(['path' => '/tmp/test.txt', 'original_name' => 'test.txt']);
+    $project->discussions()->create(['user_id' => $user->id, 'body' => 'Kickoff']);
+    $project->activities()->create(['type' => 'created']);
+
+    expect($project->milestones)->toHaveCount(1)
+        ->and($project->tasks)->toHaveCount(1)
+        ->and($project->files)->toHaveCount(1)
+        ->and($project->discussions)->toHaveCount(1)
+        ->and($project->activities)->toHaveCount(1);
+});

--- a/tests/Feature/TicketNotificationTest.php
+++ b/tests/Feature/TicketNotificationTest.php
@@ -1,0 +1,19 @@
+<?php
+
+use App\Models\Ticket;
+use App\Models\User;
+use App\Notifications\TicketCreated;
+use Illuminate\Support\Facades\Notification;
+
+it('sends email when ticket is created', function () {
+    Notification::fake();
+
+    $user = User::factory()->create();
+
+    Ticket::create([
+        'user_id' => $user->id,
+        'subject' => 'Support needed',
+    ]);
+
+    Notification::assertSentOnDemand(TicketCreated::class);
+});


### PR DESCRIPTION
## Summary
- send email notification when support ticket is created and store replies with attachments
- add project hub associations including milestones, tasks, files, discussions and activities
- expand ticket flow service to handle attachments and internal notes

## Testing
- `composer test` *(fails: require vendor; lock file out of date)*
- `composer install --no-interaction --no-progress` *(fails: lock file missing packages)*
- `composer update --no-interaction --no-progress` *(fails: curl CONNECT tunnel 403)*

------
https://chatgpt.com/codex/tasks/task_e_689f70e991288332b2959aa329b5a729