### PR TITLE
Add AI content planner and Gemini writer services

### DIFF
--- a/app/Jobs/GenerateBlogPost.php
+++ b/app/Jobs/GenerateBlogPost.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+
+class GenerateBlogPost implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public function __construct(public string $url)
+    {
+    }
+
+    public function handle(): void
+    {
+        // Job logic will generate blog post content.
+    }
+}

--- a/app/Services/AI/ContentPlanner.php
+++ b/app/Services/AI/ContentPlanner.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Services\AI;
+
+use App\Jobs\GenerateBlogPost;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+
+class ContentPlanner
+{
+    /**
+     * Scan the sitemap for internal links and enqueue blog generation jobs.
+     */
+    public function plan(): void
+    {
+        if (! config('features.ai_content_engine')) {
+            return;
+        }
+
+        foreach ($this->discoverInternalLinks() as $url) {
+            GenerateBlogPost::dispatch($url);
+        }
+    }
+
+    /**
+     * Retrieve internal URLs from the site's sitemap.
+     *
+     * @return array<int, string>
+     */
+    protected function discoverInternalLinks(): array
+    {
+        $sitemapUrl = url('/sitemap.xml');
+
+        try {
+            $response = Http::get($sitemapUrl);
+            $xml = simplexml_load_string($response->body());
+
+            $links = [];
+
+            foreach ($xml->url as $entry) {
+                $loc = (string) $entry->loc;
+
+                if (str_starts_with($loc, config('app.url'))) {
+                    $links[] = $loc;
+                }
+            }
+
+            return $links;
+        } catch (\Throwable $e) {
+            Log::error('Failed to read sitemap', ['exception' => $e]);
+        }
+
+        return [];
+    }
+}

--- a/app/Services/AI/GeminiWriter.php
+++ b/app/Services/AI/GeminiWriter.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Services\AI;
+
+use Gemini\Laravel\Facades\Gemini;
+use Illuminate\Support\Str;
+
+class GeminiWriter
+{
+    /**
+     * Draft a blog post using Gemini with meta and JSON-LD.
+     *
+     * @param  string  $topic
+     * @param  array<int, string>  $links
+     * @return array<string, mixed>
+     */
+    public function draft(string $topic, array $links = []): array
+    {
+        if (! config('features.ai_content_engine')) {
+            return [];
+        }
+
+        $prompt = $this->prompt($topic, $links);
+
+        $response = Gemini::generateContent($prompt);
+        $data = json_decode($response->text(), true) ?? [];
+
+        $body = $this->ensureInternalLinks($data['body'] ?? '', $links);
+
+        return [
+            'title' => $data['title'] ?? Str::title($topic),
+            'meta_title' => $data['meta_title'] ?? ($data['title'] ?? Str::title($topic)),
+            'meta_description' => $data['meta_description'] ?? Str::limit(strip_tags($body), 160),
+            'body' => $body,
+            'json_ld' => $data['json_ld'] ?? [],
+        ];
+    }
+
+    protected function prompt(string $topic, array $links): string
+    {
+        $linkList = implode("\n", $links);
+
+        return <<<PROMPT
+Write a detailed blog post about "{$topic}" for perfexdev360.com.
+
+Requirements:
+- Include at least three internal links from the following list:
+{$linkList}
+- Provide meta title and meta description.
+- Include valid JSON-LD for a BlogPosting.
+Return your answer as JSON with keys: title, meta_title, meta_description, body, json_ld.
+PROMPT;
+    }
+
+    protected function ensureInternalLinks(string $body, array $links): string
+    {
+        $count = preg_match_all('/href="https?:\\/\\/[^\"]+"/', $body);
+        $missing = max(0, 3 - $count);
+        $extra = array_slice($links, 0, $missing);
+
+        foreach ($extra as $url) {
+            $body .= "\n<a href=\"{$url}\">Related</a>";
+        }
+
+        return $body;
+    }
+}

--- a/config/features.php
+++ b/config/features.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+    'ai_content_engine' => env('FEATURE_AI_CONTENT_ENGINE', false),
+];


### PR DESCRIPTION
## Summary
- Add feature flag config for AI content engine
- Implement ContentPlanner to scan sitemap and queue blog generation jobs
- Add GeminiWriter service leveraging Gemini API to draft posts with internal links, meta, and JSON-LD

## Testing
- ⚠️ `composer install` (missing lock file packages)
- ⚠️ `composer test` (failed: vendor/autoload.php not found)

------
https://chatgpt.com/codex/tasks/task_e_689f72cde5748332bfe88581d1b3a286