### PR TITLE
Add document versioning and milestone notifications

### DIFF
--- a/app/Models/Document.php
+++ b/app/Models/Document.php
@@ -2,9 +2,36 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Storage;
 
 class Document extends Model
 {
-    //
+    use HasFactory;
+
+    protected $guarded = [];
+
+    protected $appends = ['signed_url'];
+
+    protected static function booted(): void
+    {
+        static::creating(function (Document $document) {
+            if ($document->version) {
+                return;
+            }
+
+            $max = static::where('user_id', $document->user_id)
+                ->where('type', $document->type)
+                ->max('version');
+
+            $document->version = $max ? $max + 1 : 1;
+        });
+    }
+
+    public function getSignedUrlAttribute(): string
+    {
+        return Storage::temporaryUrl($this->path, now()->addMinutes(30));
+    }
 }
+

--- a/app/Models/Milestone.php
+++ b/app/Models/Milestone.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Notifications\MilestoneCompleted;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
@@ -11,8 +12,20 @@ class Milestone extends Model
 
     protected $guarded = [];
 
+    protected static function booted(): void
+    {
+        static::updated(function (Milestone $milestone) {
+            if ($milestone->isDirty('status') && $milestone->status === 'done') {
+                $milestone->project->user?->notify(new MilestoneCompleted(
+                    "Milestone '{$milestone->title}' completed"
+                ));
+            }
+        });
+    }
+
     public function project()
     {
         return $this->belongsTo(Project::class);
     }
 }
+

--- a/app/Notifications/MilestoneCompleted.php
+++ b/app/Notifications/MilestoneCompleted.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Notifications;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class MilestoneCompleted extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    public function __construct(public string $message, public ?string $url = null)
+    {
+    }
+
+    public function via(object $notifiable): array
+    {
+        return ['mail', 'database'];
+    }
+
+    public function toMail(object $notifiable): MailMessage
+    {
+        return (new MailMessage)
+            ->subject('Milestone Completed')
+            ->view('emails.milestone_completed', [
+                'message' => $this->message,
+                'url' => $this->url,
+            ]);
+    }
+
+    public function toDatabase(object $notifiable): array
+    {
+        return [
+            'message' => $this->message,
+            'url' => $this->url,
+        ];
+    }
+}
+

--- a/database/factories/MilestoneFactory.php
+++ b/database/factories/MilestoneFactory.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Milestone;
+use App\Models\Project;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Milestone>
+ */
+class MilestoneFactory extends Factory
+{
+    protected $model = Milestone::class;
+
+    public function definition(): array
+    {
+        return [
+            'project_id' => Project::factory(),
+            'title' => $this->faker->sentence,
+            'due_at' => now()->addWeek(),
+            'status' => 'open',
+            'order' => 0,
+        ];
+    }
+}
+

--- a/resources/views/emails/milestone_completed.blade.php
+++ b/resources/views/emails/milestone_completed.blade.php
@@ -1,0 +1,4 @@
+<p>{{ $message }}</p>
+@if($url)
+<p><a href="{{ $url }}">View Milestone</a></p>
+@endif

--- a/tests/Feature/DocumentVersioningTest.php
+++ b/tests/Feature/DocumentVersioningTest.php
@@ -1,0 +1,30 @@
+<?php
+
+use App\Models\Document;
+use App\Models\User;
+use Illuminate\Support\Facades\Storage;
+
+it('increments version and generates signed url', function () {
+    Storage::shouldReceive('temporaryUrl')->andReturn('signed-url');
+
+    $user = User::factory()->create();
+
+    $doc1 = Document::create([
+        'user_id' => $user->id,
+        'type' => 'sow',
+        'title' => 'First SOW',
+        'path' => 'docs/sow-v1.pdf',
+    ]);
+
+    $doc2 = Document::create([
+        'user_id' => $user->id,
+        'type' => 'sow',
+        'title' => 'Second SOW',
+        'path' => 'docs/sow-v2.pdf',
+    ]);
+
+    expect($doc1->version)->toBe(1);
+    expect($doc2->version)->toBe(2);
+    expect($doc2->signed_url)->toBe('signed-url');
+});
+

--- a/tests/Feature/MilestoneNotificationTest.php
+++ b/tests/Feature/MilestoneNotificationTest.php
@@ -1,0 +1,22 @@
+<?php
+
+use App\Models\Milestone;
+use App\Models\Project;
+use App\Models\User;
+use App\Notifications\MilestoneCompleted;
+use Illuminate\Support\Facades\Notification;
+
+it('notifies user when milestone is completed', function () {
+    Notification::fake();
+
+    $user = User::factory()->create();
+    $project = Project::factory()->for($user)->create();
+    $milestone = Milestone::factory()->for($project)->create([
+        'status' => 'open',
+    ]);
+
+    $milestone->update(['status' => 'done']);
+
+    Notification::assertSentTo($user, MilestoneCompleted::class);
+});
+


### PR DESCRIPTION
## Summary
- version documents and expose signed download URLs
- notify portal users when milestones are completed
- cover document versioning and milestone notifications with tests

## Testing
- `composer test` *(fails: Script @php artisan config:clear --ansi handling the test event returned with error code 255)*
- `composer update --no-interaction --no-progress` *(fails: curl error 56 while downloading https://repo.packagist.org/packages.json: CONNECT tunnel failed, response 403)*
- `./vendor/bin/pint` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689f72c76b8c8332b1e0eed318c4ab48