### PR TITLE
Add admin AI content queue review and publish flow

### DIFF
--- a/app/Http/Controllers/Admin/AIQueueController.php
+++ b/app/Http/Controllers/Admin/AIQueueController.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\BlogPost;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
+
+class AIQueueController extends Controller
+{
+    /**
+     * Display a listing of AI-generated drafts.
+     */
+    public function index()
+    {
+        $posts = BlogPost::where('is_published', false)->get();
+
+        return view('admin.ai-queue.index', compact('posts'));
+    }
+
+    /**
+     * Approve and publish the given draft.
+     */
+    public function approve(BlogPost $blogPost): RedirectResponse
+    {
+        $blogPost->update([
+            'is_published' => true,
+            'published_at' => now(),
+        ]);
+
+        $this->refreshFeeds();
+
+        return redirect()->route('ai-queue.index')->with('status', 'Post published');
+    }
+
+    /**
+     * Reject the given draft.
+     */
+    public function reject(BlogPost $blogPost): RedirectResponse
+    {
+        $blogPost->delete();
+
+        return redirect()->route('ai-queue.index')->with('status', 'Post rejected');
+    }
+
+    /**
+     * Rebuild RSS feed, regenerate sitemap and clear caches.
+     */
+    protected function refreshFeeds(): void
+    {
+        // Regenerate sitemap
+        try {
+            Artisan::call('sitemap:generate');
+        } catch (\Throwable $e) {
+            // ignore
+        }
+
+        // Generate a very simple RSS feed
+        $posts = BlogPost::where('is_published', true)
+            ->latest('published_at')
+            ->take(20)
+            ->get();
+
+        $rss = new \SimpleXMLElement('<?xml version="1.0"?><rss version="2.0"/>');
+        $channel = $rss->addChild('channel');
+        $channel->addChild('title', config('app.name').' Blog');
+        $channel->addChild('link', url('/blog'));
+        $channel->addChild('description', 'Latest posts');
+
+        foreach ($posts as $post) {
+            $item = $channel->addChild('item');
+            $item->addChild('title', htmlspecialchars($post->title));
+            $item->addChild('link', url('/blog/'.$post->slug));
+            if ($post->published_at) {
+                $item->addChild('pubDate', $post->published_at->toRssString());
+            }
+            $item->addChild('description', htmlspecialchars(Str::limit(strip_tags($post->body), 150)));
+        }
+
+        File::put(public_path('rss.xml'), $rss->asXML() ?: '');
+
+        Cache::flush();
+    }
+}

--- a/resources/views/admin/ai-queue/index.blade.php
+++ b/resources/views/admin/ai-queue/index.blade.php
@@ -1,0 +1,36 @@
+@extends('layouts.admin')
+
+@section('admin-content')
+    <h1 class="text-2xl font-bold mb-4">AI Content Queue</h1>
+
+    <table class="w-full table-auto">
+        <thead>
+            <tr class="text-left">
+                <th class="px-2 py-1">Title</th>
+                <th class="px-2 py-1">Actions</th>
+            </tr>
+        </thead>
+        <tbody>
+            @forelse($posts as $post)
+                <tr class="border-t">
+                    <td class="px-2 py-1">{{ $post->title }}</td>
+                    <td class="px-2 py-1 space-x-2">
+                        <form method="POST" action="{{ route('ai-queue.approve', $post) }}" class="inline">
+                            @csrf
+                            <button class="text-green-600 hover:underline">Approve</button>
+                        </form>
+                        <form method="POST" action="{{ route('ai-queue.reject', $post) }}" class="inline">
+                            @csrf
+                            @method('DELETE')
+                            <button class="text-red-600 hover:underline">Reject</button>
+                        </form>
+                    </td>
+                </tr>
+            @empty
+                <tr>
+                    <td colspan="2" class="px-2 py-4 text-center text-gray-500">No drafts in queue.</td>
+                </tr>
+            @endforelse
+        </tbody>
+    </table>
+@endsection

--- a/routes/admin.php
+++ b/routes/admin.php
@@ -11,6 +11,7 @@ use App\Http\Controllers\Admin\TestimonialController;
 use App\Http\Controllers\Admin\TeamMemberController;
 use App\Http\Controllers\Admin\MediaController;
 use App\Http\Controllers\Admin\LeadController;
+use App\Http\Controllers\Admin\AIQueueController;
 
 Route::get('/', function () {
     return 'Admin Dashboard';
@@ -27,6 +28,10 @@ Route::resources([
     'team-members' => TeamMemberController::class,
     'media' => MediaController::class,
 ]);
+
+Route::get('ai-queue', [AIQueueController::class, 'index'])->name('ai-queue.index');
+Route::post('ai-queue/{blogPost}/approve', [AIQueueController::class, 'approve'])->name('ai-queue.approve');
+Route::delete('ai-queue/{blogPost}', [AIQueueController::class, 'reject'])->name('ai-queue.reject');
 
 Route::get('leads', [LeadController::class, 'index'])->name('leads.index');
 Route::post('leads/{lead}/move', [LeadController::class, 'moveStage'])->name('leads.move');


### PR DESCRIPTION
## Summary
- add AIQueueController to approve or reject AI-generated blog drafts
- regenerate sitemap, rebuild simple RSS feed, and clear caches on approval
- add admin UI view and routes for AI content queue

## Testing
- `composer test` *(fails: require vendor/autoload.php)*
- `./vendor/bin/pint` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689f740147a483328b859bb73b01ad68