### PR TITLE
Add feature tests for licensing, payments and AI flows

### DIFF
--- a/app/Http/Controllers/Api/UpdateController.php
+++ b/app/Http/Controllers/Api/UpdateController.php
@@ -45,9 +45,10 @@ class UpdateController extends Controller
         $artifact = $release->fileArtifacts()->first();
 
         $url = URL::temporarySignedRoute(
-            'download',
+            'releases.download',
             now()->addMinutes(10),
-            ['release' => $release->id, 'license_key' => $license->license_key]
+            ['release' => $release->id, 'license_key' => $license->license_key],
+            false
         );
 
         return response()->json([

--- a/app/Services/AI/SuggestedReplyService.php
+++ b/app/Services/AI/SuggestedReplyService.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Services\AI;
+
+use Gemini\Laravel\Facades\Gemini;
+
+class SuggestedReplyService
+{
+    /**
+     * Generate a suggested reply for support tickets using Gemini.
+     */
+    public function suggest(string $question): string
+    {
+        if (! config('features.ai_content_engine')) {
+            return '';
+        }
+
+        $response = Gemini::generateContent("Reply to: {$question}");
+
+        return trim($response->text());
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -8,4 +8,4 @@ use App\Http\Controllers\Api\UpdateController;
 Route::middleware('throttle:10,1')->post('/licenses/activate', ActivationController::class);
 Route::middleware('throttle:10,1')->post('/licenses/rotate', RotationController::class);
 Route::middleware('throttle:10,1')->get('/updates', UpdateController::class);
-Route::middleware('throttle:10,1')->get('/download/{release}', DownloadController::class)->name('download');
+Route::middleware('throttle:10,1')->get('/download/{release}', DownloadController::class)->name('releases.download');

--- a/tests/Feature/AiMockTest.php
+++ b/tests/Feature/AiMockTest.php
@@ -1,0 +1,70 @@
+<?php
+
+use App\Services\AI\GeminiWriter;
+use App\Services\AI\SuggestedReplyService;
+use App\Jobs\GenerateBlogPost;
+use App\Models\{BlogPost, User};
+use Gemini\Laravel\Facades\Gemini;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Queue;
+use function Pest\Laravel\actingAs;
+use function Pest\Laravel\post;
+
+it('drafts blog posts with internal links via mocked gemini', function () {
+    config()->set('features.ai_content_engine', true);
+    Gemini::shouldReceive('generateContent')->andReturn(new class {
+        public function text() {
+            return json_encode([
+                'title' => 'Title',
+                'meta_title' => 'Meta',
+                'meta_description' => 'Desc',
+                'body' => '<p>Body</p>',
+                'json_ld' => [],
+            ]);
+        }
+    });
+
+    $writer = new GeminiWriter();
+    $result = $writer->draft('topic', ['https://a.test','https://b.test','https://c.test']);
+
+    expect(substr_count($result['body'], 'https://'))->toBeGreaterThanOrEqual(3);
+});
+
+it('suggests replies using mocked gemini', function () {
+    config()->set('features.ai_content_engine', true);
+    Gemini::shouldReceive('generateContent')->andReturn(new class {
+        public function text() { return 'Thanks!'; }
+    });
+
+    $service = new SuggestedReplyService();
+    $reply = $service->suggest('How to install?');
+
+    expect($reply)->toBe('Thanks!');
+});
+
+it('regenerates sitemap when approving ai draft', function () {
+    config()->set('features.ai_content_engine', true);
+    Artisan::shouldReceive('call')->once()->with('sitemap:generate');
+    File::shouldReceive('put')->once();
+    Cache::shouldReceive('flush')->once();
+
+    $post = BlogPost::factory()->create(['is_published' => false]);
+
+    actingAs(User::factory()->create(['role' => 'admin']));
+    post(route('ai-queue.approve', $post))->assertRedirect();
+
+    expect($post->fresh()->is_published)->toBeTrue();
+});
+
+it('plans content by scanning sitemap', function () {
+    config()->set('features.ai_content_engine', true);
+    Http::fake(['*' => Http::response('<urlset><url><loc>'.url('/a').'</loc></url></urlset>')]);
+    Queue::fake();
+
+    app(App\Services\AI\ContentPlanner::class)->plan();
+
+    Queue::assertPushed(GenerateBlogPost::class);
+});

--- a/tests/Feature/LicenseActivationTest.php
+++ b/tests/Feature/LicenseActivationTest.php
@@ -1,0 +1,20 @@
+<?php
+
+use App\Models\License;
+use Spatie\Activitylog\Models\Activity;
+
+it('limits activations and logs events', function () {
+    $license = License::factory()->create(['activation_limit' => 1]);
+
+    $this->postJson('/api/licenses/activate', [
+        'license_key' => $license->license_key,
+    ])->assertOk();
+
+    $this->postJson('/api/licenses/activate', [
+        'license_key' => $license->license_key,
+    ])->assertStatus(429);
+
+    expect($license->activations()->count())->toBe(1);
+    expect($license->events()->where('event', 'activated')->count())->toBe(1);
+    expect(Activity::where('log_name', 'license')->count())->toBe(1);
+});

--- a/tests/Feature/PurchaseLicenseUpdateTest.php
+++ b/tests/Feature/PurchaseLicenseUpdateTest.php
@@ -1,0 +1,41 @@
+<?php
+
+use App\Models\{User, Product, Version, Release, ReleaseChannel, FileArtifact, Invoice};
+use App\Services\FlowService;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Facades\URL;
+use function Pest\Laravel\actingAs;
+
+it('issues license on purchase and serves update download', function () {
+    Storage::shouldReceive('disk')->with('s3')->andReturn(new class {
+        public function temporaryUrl($path, $exp) { return 'https://files.test/'.$path; }
+    });
+
+    $user = User::factory()->create();
+    $product = Product::factory()->create();
+
+    $license = app(FlowService::class)->purchaseProduct($user, $product);
+
+    $invoice = Invoice::factory()->create(['order_id' => $license->order_id]);
+    expect($invoice->order_id)->toBe($license->order_id);
+
+    $channel = ReleaseChannel::create(['name' => 'stable']);
+    $version = Version::create(['product_id' => $product->id, 'number' => '1.0.0']);
+    $release = Release::create([
+        'product_id' => $product->id,
+        'version_id' => $version->id,
+        'release_channel_id' => $channel->id,
+        'is_published' => true,
+        'released_at' => now(),
+    ]);
+    FileArtifact::create(['release_id' => $release->id, 'path' => 'build.zip', 'hash' => 'abc123']);
+
+    $response = $this->getJson('/api/updates?license_key='.$license->license_key);
+    $response->assertOk()->assertJson(['version' => '1.0.0', 'checksum' => 'abc123']);
+
+    $downloadUrl = $response->json('download_url');
+    expect($downloadUrl)->toStartWith('/api/download/');
+    expect($downloadUrl)->not->toContain('public');
+
+    actingAs($user)->get($downloadUrl)->assertRedirect('https://files.test/build.zip');
+});

--- a/tests/Feature/QuotePaymentWebhookTest.php
+++ b/tests/Feature/QuotePaymentWebhookTest.php
@@ -1,0 +1,52 @@
+<?php
+
+use App\Models\{Quote, QuoteItem, Invoice, User, Order};
+use App\Notifications\InvoicePaid;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Notification;
+use function Pest\Laravel\actingAs;
+use function Pest\Laravel\post;
+use function Pest\Laravel\postJson;
+
+it('creates invoice on quote approval and marks it paid via webhook', function () {
+    Config::set('services.stripe.webhook_secret', 'test_secret');
+    Notification::fake();
+
+    $quote = Quote::factory()->create();
+    QuoteItem::factory()->for($quote)->create([
+        'qty' => 1,
+        'unit_price' => 100,
+        'discount' => 0,
+        'tax_rate' => 0,
+    ]);
+
+    $user = User::factory()->create(['role' => 'client']);
+    actingAs($user);
+
+    post(route('portal.quotes.approve', $quote), [
+        'legal_name' => 'Jane Doe',
+        'accept_terms' => '1',
+    ])->assertSessionHasNoErrors();
+
+    $invoice = Invoice::first();
+    expect($invoice)->not->toBeNull();
+
+    $payload = [
+        'data' => [
+            'object' => [
+                'id' => 'txn_1',
+                'amount_paid' => 10000,
+                'currency' => 'usd',
+                'metadata' => ['invoice_id' => $invoice->id],
+            ],
+        ],
+    ];
+    $body = json_encode($payload);
+    $signature = hash_hmac('sha256', $body, 'test_secret');
+
+    postJson('/webhooks/stripe', $payload, ['Stripe-Signature' => $signature])
+        ->assertOk();
+
+    expect($invoice->fresh()->status)->toBe('paid');
+    Notification::assertSentTo($user, InvoicePaid::class);
+});


### PR DESCRIPTION
## Summary
- cover purchase -> invoice -> license -> update API with new tests
- add tests for activation limits and webhook payment from approved quotes
- introduce SuggestedReplyService and mock AI for blog, replies, sitemap planning
- rename release download route to avoid name collision
- ensure update API generates relative signed download URLs to avoid localhost/public redirects

## Testing
- `composer install --no-interaction --no-ansi --no-progress` *(fails: Required packages "spatie/laravel-sitemap", "spatie/laravel-permission", "spatie/laravel-medialibrary", "spatie/laravel-backup", "barryvdh/laravel-dompdf", "google-gemini-php/laravel", "stripe/stripe-php", "paypal/paypal-checkout-sdk" not present in lock file)*
- `php artisan test` *(fails: Failed opening required 'vendor/autoload.php')*

------
https://chatgpt.com/codex/tasks/task_e_689f77e6eb188332b179b8db795fb154