### PR TITLE
Use arrays with casts for structured data

### DIFF
--- a/app/Http/Controllers/Webhook/PayPalWebhookController.php
+++ b/app/Http/Controllers/Webhook/PayPalWebhookController.php
@@ -47,7 +47,7 @@ class PayPalWebhookController extends Controller
         $payment->amount = $amount;
         $payment->currency = $currency;
         $payment->status = 'succeeded';
-        $payment->meta = json_encode($payload);
+        $payment->meta = $payload;
         $payment->paid_at = now();
         $payment->save();
 

--- a/app/Http/Controllers/Webhook/StripeWebhookController.php
+++ b/app/Http/Controllers/Webhook/StripeWebhookController.php
@@ -47,7 +47,7 @@ class StripeWebhookController extends Controller
         $payment->amount = $amount ? $amount / 100 : 0;
         $payment->currency = $currency;
         $payment->status = 'succeeded';
-        $payment->meta = json_encode($payload);
+        $payment->meta = $payload;
         $payment->paid_at = now();
         $payment->save();
 

--- a/app/Models/ApiToken.php
+++ b/app/Models/ApiToken.php
@@ -2,9 +2,16 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class ApiToken extends Model
 {
-    //
+    use HasFactory;
+
+    protected $guarded = [];
+
+    protected $casts = [
+        'abilities' => 'array',
+    ];
 }

--- a/app/Models/BlogPost.php
+++ b/app/Models/BlogPost.php
@@ -11,6 +11,10 @@ class BlogPost extends Model
 
     protected $guarded = [];
 
+    protected $casts = [
+        'seo' => 'array',
+    ];
+
     public function author()
     {
         return $this->belongsTo(User::class, 'author_id');

--- a/app/Models/CaseStudy.php
+++ b/app/Models/CaseStudy.php
@@ -10,4 +10,8 @@ class CaseStudy extends Model
     use HasFactory;
 
     protected $guarded = [];
+
+    protected $casts = [
+        'meta' => 'array',
+    ];
 }

--- a/app/Models/CustomerProfile.php
+++ b/app/Models/CustomerProfile.php
@@ -2,9 +2,16 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class CustomerProfile extends Model
 {
-    //
+    use HasFactory;
+
+    protected $guarded = [];
+
+    protected $casts = [
+        'address' => 'array',
+    ];
 }

--- a/app/Models/Document.php
+++ b/app/Models/Document.php
@@ -14,6 +14,10 @@ class Document extends Model
 
     protected $appends = ['signed_url'];
 
+    protected $casts = [
+        'meta' => 'array',
+    ];
+
     protected static function booted(): void
     {
         static::creating(function (Document $document) {

--- a/app/Models/Edition.php
+++ b/app/Models/Edition.php
@@ -2,9 +2,16 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class Edition extends Model
 {
-    //
+    use HasFactory;
+
+    protected $guarded = [];
+
+    protected $casts = [
+        'features' => 'array',
+    ];
 }

--- a/app/Models/Media.php
+++ b/app/Models/Media.php
@@ -10,4 +10,11 @@ class Media extends Model
     use HasFactory;
 
     protected $guarded = [];
+
+    protected $casts = [
+        'manipulations' => 'array',
+        'custom_properties' => 'array',
+        'generated_conversions' => 'array',
+        'responsive_images' => 'array',
+    ];
 }

--- a/app/Models/Order.php
+++ b/app/Models/Order.php
@@ -21,6 +21,10 @@ class Order extends Model
         'user_id',
     ];
 
+    protected $casts = [
+        'billing_info' => 'array',
+    ];
+
     /**
      * Order belongs to a user.
      */

--- a/app/Models/OrderItem.php
+++ b/app/Models/OrderItem.php
@@ -2,9 +2,16 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class OrderItem extends Model
 {
-    //
+    use HasFactory;
+
+    protected $guarded = [];
+
+    protected $casts = [
+        'meta' => 'array',
+    ];
 }

--- a/app/Models/Organization.php
+++ b/app/Models/Organization.php
@@ -2,9 +2,16 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class Organization extends Model
 {
-    //
+    use HasFactory;
+
+    protected $guarded = [];
+
+    protected $casts = [
+        'billing_address' => 'array',
+    ];
 }

--- a/app/Models/Payment.php
+++ b/app/Models/Payment.php
@@ -23,6 +23,10 @@ class Payment extends Model
         'paid_at',
     ];
 
+    protected $casts = [
+        'meta' => 'array',
+    ];
+
     protected static function booted(): void
     {
         static::created(function (Payment $payment): void {

--- a/app/Models/PortalNotification.php
+++ b/app/Models/PortalNotification.php
@@ -2,9 +2,16 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class PortalNotification extends Model
 {
-    //
+    use HasFactory;
+
+    protected $guarded = [];
+
+    protected $casts = [
+        'data' => 'array',
+    ];
 }

--- a/app/Models/Product.php
+++ b/app/Models/Product.php
@@ -11,6 +11,10 @@ class Product extends Model
 
     protected $guarded = [];
 
+    protected $casts = [
+        'seo' => 'array',
+    ];
+
     public function versions()
     {
         return $this->hasMany(Version::class);

--- a/app/Models/Section.php
+++ b/app/Models/Section.php
@@ -10,4 +10,8 @@ class Section extends Model
     use HasFactory;
 
     protected $guarded = [];
+
+    protected $casts = [
+        'content' => 'array',
+    ];
 }

--- a/app/Models/Service.php
+++ b/app/Models/Service.php
@@ -18,6 +18,10 @@ class Service extends Model
      */
     protected $guarded = [];
 
+    protected $casts = [
+        'seo' => 'array',
+    ];
+
     /**
      * Options available for the service.
      */

--- a/app/Models/Version.php
+++ b/app/Models/Version.php
@@ -13,6 +13,10 @@ class Version extends Model
 
     protected $guarded = [];
 
+    protected $casts = [
+        'notes' => 'array',
+    ];
+
     public function product(): BelongsTo
     {
         return $this->belongsTo(Product::class);

--- a/database/factories/MediaFactory.php
+++ b/database/factories/MediaFactory.php
@@ -3,6 +3,7 @@
 namespace Database\Factories;
 
 use App\Models\Media;
+use App\Models\Page;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Str;
 
@@ -13,8 +14,8 @@ class MediaFactory extends Factory
     public function definition(): array
     {
         return [
-            'model_type' => 'App\\Models\\Page',
-            'model_id' => 1,
+            'model_type' => Page::class,
+            'model_id' => Page::factory(),
             'uuid' => Str::uuid()->toString(),
             'collection_name' => 'default',
             'name' => $this->faker->word(),

--- a/database/migrations/2025_08_14_113207_create_perfex_dev_360_tables.php
+++ b/database/migrations/2025_08_14_113207_create_perfex_dev_360_tables.php
@@ -139,7 +139,7 @@ return new class extends Migration {
             $table->uuid('id')->primary();
             $table->string('type');
             $table->morphs('notifiable');
-            $table->text('data');
+            $table->json('data');
             $table->timestamp('read_at')->nullable();
             $table->timestamps();
         });


### PR DESCRIPTION
## Summary
- Remove manual JSON encoding in webhook controllers and persist payloads via model casting
- Cast structured attributes like billing addresses, SEO metadata, and features across models
- Store notification data as JSON and seed media without hard-coded IDs

## Testing
- `php artisan migrate:fresh --seed` *(fails: Failed opening required '/workspace/PERFEXDEV-360/vendor/autoload.php')*
- `composer install` *(fails: Required packages missing from lock file)*
- `composer update` *(fails: curl error 56 CONNECT tunnel failed 403)*
- `php artisan test` *(fails: Failed opening required '/workspace/PERFEXDEV-360/vendor/autoload.php')*


------
https://chatgpt.com/codex/tasks/task_e_689f825ad2248332b5aa7ae6e8a9d9b3