### PR TITLE
Add optional project link to tickets

### DIFF
--- a/database/migrations/2025_08_14_113207_create_perfex_dev_360_tables.php
+++ b/database/migrations/2025_08_14_113207_create_perfex_dev_360_tables.php
@@ -668,6 +668,14 @@ return new class extends Migration {
             $table->timestamps();
         });
 
+        Schema::table('tickets', function (Blueprint $table) {
+            $table->foreignId('project_id')
+                ->nullable()
+                ->constrained()
+                ->nullOnDelete()
+                ->after('user_id');
+        });
+
         Schema::create('milestones', function (Blueprint $table) {
             $table->id();
             $table->foreignId('project_id')->constrained()->cascadeOnDelete();
@@ -744,9 +752,9 @@ return new class extends Migration {
         Schema::dropIfExists('project_files');
         Schema::dropIfExists('tasks');
         Schema::dropIfExists('milestones');
-        Schema::dropIfExists('projects');
         Schema::dropIfExists('ticket_replies');
         Schema::dropIfExists('tickets');
+        Schema::dropIfExists('projects');
 
         Schema::dropIfExists('service_requests');
         Schema::dropIfExists('service_case_study');


### PR DESCRIPTION
## Summary
- allow tickets to reference projects via nullable `project_id` foreign key
- adjust migration rollback order for new relationship

## Testing
- `./vendor/bin/pint` *(fails: No such file or directory)*
- `php artisan migrate:fresh --seed` *(fails: vendor/autoload.php missing)*
- `php artisan test` *(fails: vendor/autoload.php missing)*

------
https://chatgpt.com/codex/tasks/task_e_689f85d25e708332ae43b9a64231a1bb