### PR TITLE
Associate tickets with projects

### DIFF
--- a/database/factories/TicketFactory.php
+++ b/database/factories/TicketFactory.php
@@ -2,6 +2,7 @@
 
 namespace Database\Factories;
 
+use App\Models\Project;
 use App\Models\Ticket;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
@@ -15,6 +16,7 @@ class TicketFactory extends Factory
     public function definition(): array
     {
         return [
+            'project_id' => Project::factory(),
             'subject' => $this->faker->sentence(),
             'category' => $this->faker->word(),
             'priority' => $this->faker->randomElement(['low','normal','high','urgent']),

--- a/database/migrations/2025_08_14_113207_create_perfex_dev_360_tables.php
+++ b/database/migrations/2025_08_14_113207_create_perfex_dev_360_tables.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Models\Project;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
@@ -669,7 +670,7 @@ return new class extends Migration {
         });
 
         Schema::table('tickets', function (Blueprint $table) {
-            $table->foreignId('project_id')
+            $table->foreignIdFor(Project::class)
                 ->nullable()
                 ->constrained()
                 ->nullOnDelete()


### PR DESCRIPTION
## Summary
- tie tickets to projects via nullable foreign key
- seed tickets with related project factory

## Testing
- `php artisan migrate:fresh --seed` *(fails: require(/workspace/PERFEXDEV-360/vendor/autoload.php): Failed to open stream)*
- `composer update` *(fails: curl error 56 while downloading https://repo.packagist.org/packages.json: CONNECT tunnel failed, response 403)*
- `php artisan test` *(fails: require(/workspace/PERFEXDEV-360/vendor/autoload.php): Failed to open stream)*

------
https://chatgpt.com/codex/tasks/task_e_689f88df06848332bbbaac6a8472ff40