### PR TITLE
Add validation rules for tickets and projects

### DIFF
--- a/app/Http/Controllers/Admin/ProjectController.php
+++ b/app/Http/Controllers/Admin/ProjectController.php
@@ -26,7 +26,11 @@ class ProjectController extends Controller
 
     public function store(ProjectRequest $request)
     {
-        $project = $this->repository->create($request->validated());
+        $data = $request->validated();
+        $data['user_id'] = $data['user_id'] ?? $request->user()->id;
+
+        $project = $this->repository->create($data);
+
         return response()->json($project, 201);
     }
 
@@ -42,7 +46,11 @@ class ProjectController extends Controller
 
     public function update(ProjectRequest $request, Project $project)
     {
-        $project = $this->repository->update($project, $request->validated());
+        $data = $request->validated();
+        $data['user_id'] = $data['user_id'] ?? $project->user_id;
+
+        $project = $this->repository->update($project, $data);
+
         return response()->json($project);
     }
 

--- a/app/Http/Controllers/Admin/TicketController.php
+++ b/app/Http/Controllers/Admin/TicketController.php
@@ -26,7 +26,11 @@ class TicketController extends Controller
 
     public function store(TicketRequest $request)
     {
-        $ticket = $this->repository->create($request->validated());
+        $data = $request->validated();
+        $data['user_id'] = $data['user_id'] ?? $request->user()->id;
+
+        $ticket = $this->repository->create($data);
+
         return response()->json($ticket, 201);
     }
 
@@ -42,7 +46,11 @@ class TicketController extends Controller
 
     public function update(TicketRequest $request, Ticket $ticket)
     {
-        $ticket = $this->repository->update($ticket, $request->validated());
+        $data = $request->validated();
+        $data['user_id'] = $data['user_id'] ?? $ticket->user_id;
+
+        $ticket = $this->repository->update($ticket, $data);
+
         return response()->json($ticket);
     }
 

--- a/app/Http/Requests/Admin/ProjectRequest.php
+++ b/app/Http/Requests/Admin/ProjectRequest.php
@@ -13,6 +13,12 @@ class ProjectRequest extends FormRequest
 
     public function rules(): array
     {
-        return [];
+        return [
+            'name' => ['required', 'string', 'max:255'],
+            'status' => ['required', 'in:active,on_hold,completed,archived'],
+            'start_at' => ['nullable', 'date'],
+            'due_at' => ['nullable', 'date', 'after_or_equal:start_at'],
+            'user_id' => ['nullable', 'exists:users,id'],
+        ];
     }
 }

--- a/app/Http/Requests/Admin/TicketRequest.php
+++ b/app/Http/Requests/Admin/TicketRequest.php
@@ -13,6 +13,13 @@ class TicketRequest extends FormRequest
 
     public function rules(): array
     {
-        return [];
+        return [
+            'subject' => ['required', 'string', 'max:255'],
+            'category' => ['nullable', 'string', 'max:255'],
+            'priority' => ['required', 'in:low,normal,high,urgent'],
+            'status' => ['required', 'in:open,pending,resolved,closed'],
+            'user_id' => ['nullable', 'exists:users,id'],
+            'project_id' => ['nullable', 'exists:projects,id'],
+        ];
     }
 }

--- a/database/factories/ProjectFactory.php
+++ b/database/factories/ProjectFactory.php
@@ -3,6 +3,7 @@
 namespace Database\Factories;
 
 use App\Models\Project;
+use App\Models\User;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
@@ -15,6 +16,7 @@ class ProjectFactory extends Factory
     public function definition(): array
     {
         return [
+            'user_id' => User::factory(),
             'name' => $this->faker->words(3, true),
             'status' => $this->faker->randomElement(['active','on_hold','completed']),
             'start_at' => now(),

--- a/database/factories/TicketFactory.php
+++ b/database/factories/TicketFactory.php
@@ -2,7 +2,9 @@
 
 namespace Database\Factories;
 
+use App\Models\Project;
 use App\Models\Ticket;
+use App\Models\User;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
@@ -15,10 +17,12 @@ class TicketFactory extends Factory
     public function definition(): array
     {
         return [
+            'user_id' => User::factory(),
             'subject' => $this->faker->sentence(),
             'category' => $this->faker->word(),
             'priority' => $this->faker->randomElement(['low','normal','high','urgent']),
             'status' => $this->faker->randomElement(['open','pending','resolved','closed']),
+            'project_id' => Project::factory(),
             'last_activity_at' => now(),
         ];
     }


### PR DESCRIPTION
## Summary
- enforce validation for ticket subject, category, priority, status, user, and project
- add project validation for name, status, dates, and user ownership
- ensure controllers attach a user when creating or updating records
- update factories to supply required user and project fields

## Testing
- `composer install` *(fails: Required package not present in lock file)*
- `php artisan test` *(fails: vendor/autoload.php missing)*

------
https://chatgpt.com/codex/tasks/task_e_689f88ec3108833294e7e8d157a455d7