### PR TITLE
Implement portal CRUD for quotes, projects and tickets

### DIFF
--- a/app/Http/Controllers/Portal/ProjectController.php
+++ b/app/Http/Controllers/Portal/ProjectController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Portal;
 
 use App\Http\Controllers\Controller;
+use App\Http\Requests\Portal\ProjectRequest;
 use App\Models\Project;
 use Illuminate\Http\Request;
 
@@ -11,56 +12,103 @@ class ProjectController extends Controller
     /**
      * Display a listing of the resource.
      */
-    public function index()
+    public function index(Request $request)
     {
-        //
+        $projects = $request->user()->projects()->latest()->get();
+
+        if ($request->wantsJson()) {
+            return response()->json($projects);
+        }
+
+        return view('portal.projects.index', compact('projects'));
     }
 
     /**
      * Show the form for creating a new resource.
      */
-    public function create()
+    public function create(Request $request)
     {
-        //
+        if ($request->wantsJson()) {
+            return response()->json([]);
+        }
+
+        return view('portal.projects.create');
     }
 
     /**
      * Store a newly created resource in storage.
      */
-    public function store(Request $request)
+    public function store(ProjectRequest $request)
     {
-        //
+        $project = $request->user()->projects()->create($request->validated());
+
+        if ($request->wantsJson()) {
+            return response()->json($project, 201);
+        }
+
+        return redirect()->route('projects.show', $project)
+            ->with('status', 'Project created.');
     }
 
     /**
      * Display the specified resource.
      */
-    public function show(Project $project)
+    public function show(Request $request, Project $project)
     {
-        //
+        abort_if($project->user_id !== $request->user()->id, 403);
+
+        if ($request->wantsJson()) {
+            return response()->json($project);
+        }
+
+        return view('portal.projects.show', compact('project'));
     }
 
     /**
      * Show the form for editing the specified resource.
      */
-    public function edit(Project $project)
+    public function edit(Request $request, Project $project)
     {
-        //
+        abort_if($project->user_id !== $request->user()->id, 403);
+
+        if ($request->wantsJson()) {
+            return response()->json($project);
+        }
+
+        return view('portal.projects.edit', compact('project'));
     }
 
     /**
      * Update the specified resource in storage.
      */
-    public function update(Request $request, Project $project)
+    public function update(ProjectRequest $request, Project $project)
     {
-        //
+        abort_if($project->user_id !== $request->user()->id, 403);
+
+        $project->update($request->validated());
+
+        if ($request->wantsJson()) {
+            return response()->json($project);
+        }
+
+        return redirect()->route('projects.show', $project)
+            ->with('status', 'Project updated.');
     }
 
     /**
      * Remove the specified resource from storage.
      */
-    public function destroy(Project $project)
+    public function destroy(Request $request, Project $project)
     {
-        //
+        abort_if($project->user_id !== $request->user()->id, 403);
+
+        $project->delete();
+
+        if ($request->wantsJson()) {
+            return response()->json(null, 204);
+        }
+
+        return redirect()->route('projects.index')
+            ->with('status', 'Project deleted.');
     }
 }

--- a/app/Http/Controllers/Portal/QuoteController.php
+++ b/app/Http/Controllers/Portal/QuoteController.php
@@ -3,70 +3,120 @@
 namespace App\Http\Controllers\Portal;
 
 use App\Http\Controllers\Controller;
+use App\Http\Requests\Portal\QuoteRequest;
 use App\Models\Quote;
-use Illuminate\Http\Request;
 use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
 
 class QuoteController extends Controller
 {
     /**
      * Display a listing of the resource.
      */
-    public function index()
+    public function index(Request $request)
     {
-        //
+        $quotes = $request->user()->quotes()->latest()->get();
+
+        if ($request->wantsJson()) {
+            return response()->json($quotes);
+        }
+
+        return view('portal.quotes.index', compact('quotes'));
     }
 
     /**
      * Show the form for creating a new resource.
      */
-    public function create()
+    public function create(Request $request)
     {
-        //
+        if ($request->wantsJson()) {
+            return response()->json([]);
+        }
+
+        return view('portal.quotes.create');
     }
 
     /**
      * Store a newly created resource in storage.
      */
-    public function store(Request $request)
+    public function store(QuoteRequest $request)
     {
-        //
+        $quote = $request->user()->quotes()->create($request->validated());
+
+        if ($request->wantsJson()) {
+            return response()->json($quote, 201);
+        }
+
+        return redirect()->route('quotes.show', $quote)
+            ->with('status', 'Quote created.');
     }
 
     /**
      * Display the specified resource.
      */
-    public function show(Quote $quote)
+    public function show(Request $request, Quote $quote)
     {
-        //
+        abort_if($quote->user_id !== $request->user()->id, 403);
+
+        if ($request->wantsJson()) {
+            return response()->json($quote);
+        }
+
+        return view('portal.quotes.show', compact('quote'));
     }
 
     /**
      * Show the form for editing the specified resource.
      */
-    public function edit(Quote $quote)
+    public function edit(Request $request, Quote $quote)
     {
-        //
+        abort_if($quote->user_id !== $request->user()->id, 403);
+
+        if ($request->wantsJson()) {
+            return response()->json($quote);
+        }
+
+        return view('portal.quotes.edit', compact('quote'));
     }
 
     /**
      * Update the specified resource in storage.
      */
-    public function update(Request $request, Quote $quote)
+    public function update(QuoteRequest $request, Quote $quote)
     {
-        //
+        abort_if($quote->user_id !== $request->user()->id, 403);
+
+        $quote->update($request->validated());
+
+        if ($request->wantsJson()) {
+            return response()->json($quote);
+        }
+
+        return redirect()->route('quotes.show', $quote)
+            ->with('status', 'Quote updated.');
     }
 
     /**
      * Remove the specified resource from storage.
      */
-    public function destroy(Quote $quote)
+    public function destroy(Request $request, Quote $quote)
     {
-        //
+        abort_if($quote->user_id !== $request->user()->id, 403);
+
+        $quote->delete();
+
+        if ($request->wantsJson()) {
+            return response()->json(null, 204);
+        }
+
+        return redirect()->route('quotes.index')
+            ->with('status', 'Quote deleted.');
     }
 
     public function approve(Request $request, Quote $quote): RedirectResponse
     {
+        abort_if($quote->user_id !== $request->user()->id, 403);
+
         $validated = $request->validate([
             'legal_name' => ['required', 'string'],
             'accept_terms' => ['accepted'],
@@ -79,6 +129,8 @@ class QuoteController extends Controller
 
     public function reject(Request $request, Quote $quote): RedirectResponse
     {
+        abort_if($quote->user_id !== $request->user()->id, 403);
+
         $validated = $request->validate([
             'legal_name' => ['required', 'string'],
             'accept_terms' => ['accepted'],

--- a/app/Http/Controllers/Portal/TicketController.php
+++ b/app/Http/Controllers/Portal/TicketController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Portal;
 
 use App\Http\Controllers\Controller;
+use App\Http\Requests\Portal\TicketRequest;
 use App\Models\Ticket;
 use Illuminate\Http\Request;
 
@@ -11,56 +12,105 @@ class TicketController extends Controller
     /**
      * Display a listing of the resource.
      */
-    public function index()
+    public function index(Request $request)
     {
-        //
+        $tickets = $request->user()->tickets()->latest()->get();
+
+        if ($request->wantsJson()) {
+            return response()->json($tickets);
+        }
+
+        return view('portal.tickets.index', compact('tickets'));
     }
 
     /**
      * Show the form for creating a new resource.
      */
-    public function create()
+    public function create(Request $request)
     {
-        //
+        if ($request->wantsJson()) {
+            return response()->json([]);
+        }
+
+        return view('portal.tickets.create');
     }
 
     /**
      * Store a newly created resource in storage.
      */
-    public function store(Request $request)
+    public function store(TicketRequest $request)
     {
-        //
+        $ticket = $request->user()->tickets()->create($request->validated());
+
+        if ($request->wantsJson()) {
+            return response()->json($ticket, 201);
+        }
+
+        return redirect()->route('tickets.show', $ticket)
+            ->with('status', 'Ticket created.');
     }
 
     /**
      * Display the specified resource.
      */
-    public function show(Ticket $ticket)
+    public function show(Request $request, Ticket $ticket)
     {
-        //
+        abort_if($ticket->user_id !== $request->user()->id, 403);
+
+        $ticket->load('replies');
+
+        if ($request->wantsJson()) {
+            return response()->json($ticket);
+        }
+
+        return view('portal.tickets.show', compact('ticket'));
     }
 
     /**
      * Show the form for editing the specified resource.
      */
-    public function edit(Ticket $ticket)
+    public function edit(Request $request, Ticket $ticket)
     {
-        //
+        abort_if($ticket->user_id !== $request->user()->id, 403);
+
+        if ($request->wantsJson()) {
+            return response()->json($ticket);
+        }
+
+        return view('portal.tickets.edit', compact('ticket'));
     }
 
     /**
      * Update the specified resource in storage.
      */
-    public function update(Request $request, Ticket $ticket)
+    public function update(TicketRequest $request, Ticket $ticket)
     {
-        //
+        abort_if($ticket->user_id !== $request->user()->id, 403);
+
+        $ticket->update($request->validated());
+
+        if ($request->wantsJson()) {
+            return response()->json($ticket);
+        }
+
+        return redirect()->route('tickets.show', $ticket)
+            ->with('status', 'Ticket updated.');
     }
 
     /**
      * Remove the specified resource from storage.
      */
-    public function destroy(Ticket $ticket)
+    public function destroy(Request $request, Ticket $ticket)
     {
-        //
+        abort_if($ticket->user_id !== $request->user()->id, 403);
+
+        $ticket->delete();
+
+        if ($request->wantsJson()) {
+            return response()->json(null, 204);
+        }
+
+        return redirect()->route('tickets.index')
+            ->with('status', 'Ticket deleted.');
     }
 }

--- a/app/Http/Requests/Portal/ProjectRequest.php
+++ b/app/Http/Requests/Portal/ProjectRequest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Requests\Portal;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class ProjectRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'name' => ['required', 'string', 'max:255'],
+            'status' => ['sometimes', 'in:active,on_hold,completed,archived'],
+            'start_at' => ['nullable', 'date'],
+            'due_at' => ['nullable', 'date', 'after_or_equal:start_at'],
+        ];
+    }
+}

--- a/app/Http/Requests/Portal/QuoteRequest.php
+++ b/app/Http/Requests/Portal/QuoteRequest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Requests\Portal;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class QuoteRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'number' => ['required', 'string', 'max:255'],
+            'valid_until' => ['nullable', 'date'],
+            'status' => ['sometimes', 'in:draft,sent,approved,rejected,expired'],
+        ];
+    }
+}

--- a/app/Http/Requests/Portal/TicketRequest.php
+++ b/app/Http/Requests/Portal/TicketRequest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Requests\Portal;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class TicketRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'subject' => ['required', 'string', 'max:255'],
+            'category' => ['nullable', 'string', 'max:255'],
+            'priority' => ['required', 'in:low,normal,high,urgent'],
+            'status' => ['sometimes', 'in:open,pending,resolved,closed'],
+        ];
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -64,4 +64,28 @@ class User extends Authenticatable implements MustVerifyEmail
     {
         return $this->hasMany(Order::class);
     }
+
+    /**
+     * Tickets opened by the user.
+     */
+    public function tickets(): HasMany
+    {
+        return $this->hasMany(Ticket::class);
+    }
+
+    /**
+     * Projects owned by the user.
+     */
+    public function projects(): HasMany
+    {
+        return $this->hasMany(Project::class);
+    }
+
+    /**
+     * Quotes belonging to the user.
+     */
+    public function quotes(): HasMany
+    {
+        return $this->hasMany(Quote::class);
+    }
 }

--- a/resources/views/portal/projects/create.blade.php
+++ b/resources/views/portal/projects/create.blade.php
@@ -1,0 +1,7 @@
+@extends('layouts.portal')
+
+@section('portal-content')
+<div class="p-4">
+    <h1 class="text-2xl font-bold mb-4">Create Project</h1>
+</div>
+@endsection

--- a/resources/views/portal/projects/edit.blade.php
+++ b/resources/views/portal/projects/edit.blade.php
@@ -1,0 +1,7 @@
+@extends('layouts.portal')
+
+@section('portal-content')
+<div class="p-4">
+    <h1 class="text-2xl font-bold mb-4">Edit Project</h1>
+</div>
+@endsection

--- a/resources/views/portal/quotes/create.blade.php
+++ b/resources/views/portal/quotes/create.blade.php
@@ -1,0 +1,7 @@
+@extends('layouts.portal')
+
+@section('portal-content')
+<div class="p-4">
+    <h1 class="text-2xl font-bold mb-4">Create Quote</h1>
+</div>
+@endsection

--- a/resources/views/portal/quotes/edit.blade.php
+++ b/resources/views/portal/quotes/edit.blade.php
@@ -1,0 +1,7 @@
+@extends('layouts.portal')
+
+@section('portal-content')
+<div class="p-4">
+    <h1 class="text-2xl font-bold mb-4">Edit Quote</h1>
+</div>
+@endsection

--- a/resources/views/portal/tickets/edit.blade.php
+++ b/resources/views/portal/tickets/edit.blade.php
@@ -1,0 +1,7 @@
+@extends('layouts.portal')
+
+@section('portal-content')
+<div class="p-4">
+    <h1 class="text-2xl font-bold mb-4">Edit Ticket</h1>
+</div>
+@endsection

--- a/routes/portal.php
+++ b/routes/portal.php
@@ -5,16 +5,22 @@ use App\Http\Controllers\Portal\LicenseController;
 use App\Http\Controllers\Portal\PurchaseController;
 use App\Http\Controllers\Portal\QuoteController;
 use App\Http\Controllers\Portal\InvoiceController;
+use App\Http\Controllers\Portal\ProjectController;
+use App\Http\Controllers\Portal\TicketController;
 
 Route::middleware(['auth', 'verified', 'twofactor'])->group(function () {
     Route::get('/', function () {
         return 'Client Portal';
     });
 
+    Route::resource('quotes', QuoteController::class);
     Route::post('quotes/{quote}/approve', [QuoteController::class, 'approve'])
         ->name('quotes.approve');
     Route::post('quotes/{quote}/reject', [QuoteController::class, 'reject'])
         ->name('quotes.reject');
+
+    Route::resource('projects', ProjectController::class);
+    Route::resource('tickets', TicketController::class);
 
     Route::resource('invoices', InvoiceController::class)->only(['show']);
     Route::post('invoices/{invoice}/pay', [InvoiceController::class, 'pay'])


### PR DESCRIPTION
## Summary
- add full CRUD endpoints for portal tickets, projects and quotes
- validate portal requests with dedicated form request classes
- restrict access to authenticated user's own resources

## Testing
- `php artisan test` *(fails: Failed opening required '/workspace/PERFEXDEV-360/vendor/autoload.php')*

------
https://chatgpt.com/codex/tasks/task_e_689f88ee5cc4833289cddf3fea4a381b