### PR TITLE
Add project and ticket routes for admin and portal

### DIFF
--- a/routes/admin.php
+++ b/routes/admin.php
@@ -13,30 +13,36 @@ use App\Http\Controllers\Admin\MediaController;
 use App\Http\Controllers\Admin\LeadController;
 use App\Http\Controllers\Admin\AIQueueController;
 use App\Http\Controllers\Admin\SettingController;
+use App\Http\Controllers\Admin\ProjectController;
+use App\Http\Controllers\Admin\TicketController;
 
-Route::get('/', function () {
-    return 'Admin Dashboard';
+Route::middleware(['auth', 'verified', 'twofactor'])->group(function () {
+    Route::get('/', function () {
+        return 'Admin Dashboard';
+    });
+
+    Route::resources([
+        'pages' => PageController::class,
+        'sections' => SectionController::class,
+        'blog-posts' => BlogPostController::class,
+        'categories' => CategoryController::class,
+        'tags' => TagController::class,
+        'case-studies' => CaseStudyController::class,
+        'testimonials' => TestimonialController::class,
+        'team-members' => TeamMemberController::class,
+        'media' => MediaController::class,
+        'projects' => ProjectController::class,
+        'tickets' => TicketController::class,
+    ]);
+
+    Route::get('ai-queue', [AIQueueController::class, 'index'])->name('ai-queue.index');
+    Route::post('ai-queue/{blogPost}/approve', [AIQueueController::class, 'approve'])->name('ai-queue.approve');
+    Route::delete('ai-queue/{blogPost}', [AIQueueController::class, 'reject'])->name('ai-queue.reject');
+
+    Route::get('leads', [LeadController::class, 'index'])->name('leads.index');
+    Route::post('leads/{lead}/move', [LeadController::class, 'moveStage'])->name('leads.move');
+
+    Route::get('settings', [SettingController::class, 'edit'])->name('settings.edit');
+    Route::put('settings', [SettingController::class, 'update'])->name('settings.update');
 });
-
-Route::resources([
-    'pages' => PageController::class,
-    'sections' => SectionController::class,
-    'blog-posts' => BlogPostController::class,
-    'categories' => CategoryController::class,
-    'tags' => TagController::class,
-    'case-studies' => CaseStudyController::class,
-    'testimonials' => TestimonialController::class,
-    'team-members' => TeamMemberController::class,
-    'media' => MediaController::class,
-]);
-
-Route::get('ai-queue', [AIQueueController::class, 'index'])->name('ai-queue.index');
-Route::post('ai-queue/{blogPost}/approve', [AIQueueController::class, 'approve'])->name('ai-queue.approve');
-Route::delete('ai-queue/{blogPost}', [AIQueueController::class, 'reject'])->name('ai-queue.reject');
-
-Route::get('leads', [LeadController::class, 'index'])->name('leads.index');
-Route::post('leads/{lead}/move', [LeadController::class, 'moveStage'])->name('leads.move');
-
-Route::get('settings', [SettingController::class, 'edit'])->name('settings.edit');
-Route::put('settings', [SettingController::class, 'update'])->name('settings.update');
 

--- a/routes/portal.php
+++ b/routes/portal.php
@@ -5,6 +5,8 @@ use App\Http\Controllers\Portal\LicenseController;
 use App\Http\Controllers\Portal\PurchaseController;
 use App\Http\Controllers\Portal\QuoteController;
 use App\Http\Controllers\Portal\InvoiceController;
+use App\Http\Controllers\Portal\ProjectController;
+use App\Http\Controllers\Portal\TicketController;
 
 Route::middleware(['auth', 'verified', 'twofactor'])->group(function () {
     Route::get('/', function () {
@@ -15,6 +17,8 @@ Route::middleware(['auth', 'verified', 'twofactor'])->group(function () {
         ->name('quotes.approve');
     Route::post('quotes/{quote}/reject', [QuoteController::class, 'reject'])
         ->name('quotes.reject');
+
+    Route::resource('quotes', QuoteController::class)->only(['index', 'show']);
 
     Route::resource('invoices', InvoiceController::class)->only(['show']);
     Route::post('invoices/{invoice}/pay', [InvoiceController::class, 'pay'])
@@ -29,5 +33,8 @@ Route::middleware(['auth', 'verified', 'twofactor'])->group(function () {
     Route::get('licenses/{license}/download/{release}', [LicenseController::class, 'download'])
         ->name('licenses.download')
         ->middleware('signed');
+
+    Route::resource('projects', ProjectController::class);
+    Route::resource('tickets', TicketController::class);
 });
 


### PR DESCRIPTION
## Summary
- expose admin routes for projects and tickets behind auth, verification, and two-factor middleware
- add portal routes for projects, tickets, and read-only quotes

## Testing
- `./vendor/bin/pint routes/admin.php routes/portal.php` *(fails: No such file or directory)*
- `php artisan test` *(fails: Failed opening required 'vendor/autoload.php')*

------
https://chatgpt.com/codex/tasks/task_e_689f88fa090083328a258afc032c440f