### PR TITLE
feat(portal): add quote management

### DIFF
--- a/app/Http/Controllers/Portal/QuoteController.php
+++ b/app/Http/Controllers/Portal/QuoteController.php
@@ -6,63 +6,120 @@ use App\Http\Controllers\Controller;
 use App\Models\Quote;
 use Illuminate\Http\Request;
 use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Str;
 
 class QuoteController extends Controller
 {
     /**
-     * Display a listing of the resource.
+     * Display a listing of the user's quotes.
      */
-    public function index()
+    public function index(Request $request)
     {
-        //
+        $quotes = $request->user()
+            ->quotes()
+            ->latest()
+            ->paginate(10);
+
+        if ($request->wantsJson()) {
+            return response()->json($quotes);
+        }
+
+        return view('portal.quotes.index', compact('quotes'));
     }
 
     /**
-     * Show the form for creating a new resource.
+     * Show the form for creating a new quote.
      */
     public function create()
     {
-        //
+        return view('portal.quotes.create');
     }
 
     /**
-     * Store a newly created resource in storage.
+     * Store a newly created quote for the authenticated user.
      */
     public function store(Request $request)
     {
-        //
+        $validated = $request->validate([
+            'valid_until' => ['nullable', 'date'],
+        ]);
+
+        $quote = $request->user()->quotes()->create([
+            'number' => 'Q' . now()->format('YmdHis') . Str::random(4),
+            'status' => 'draft',
+            'valid_until' => $validated['valid_until'] ?? null,
+        ]);
+
+        if ($request->wantsJson()) {
+            return response()->json($quote, 201);
+        }
+
+        return redirect()->route('portal.quotes.show', $quote)
+            ->with('status', 'Quote created.');
     }
 
     /**
-     * Display the specified resource.
+     * Display the specified quote.
      */
-    public function show(Quote $quote)
+    public function show(Quote $quote, Request $request)
     {
-        //
+        abort_if($quote->user_id !== $request->user()->id, 403);
+
+        $quote->load('items');
+
+        if ($request->wantsJson()) {
+            return response()->json($quote);
+        }
+
+        return view('portal.quotes.show', compact('quote'));
     }
 
     /**
-     * Show the form for editing the specified resource.
+     * Show the form for editing the specified quote.
      */
-    public function edit(Quote $quote)
+    public function edit(Quote $quote, Request $request)
     {
-        //
+        abort_if($quote->user_id !== $request->user()->id, 403);
+
+        return view('portal.quotes.edit', compact('quote'));
     }
 
     /**
-     * Update the specified resource in storage.
+     * Update the specified quote.
      */
     public function update(Request $request, Quote $quote)
     {
-        //
+        abort_if($quote->user_id !== $request->user()->id, 403);
+
+        $validated = $request->validate([
+            'valid_until' => ['nullable', 'date'],
+        ]);
+
+        $quote->update($validated);
+
+        if ($request->wantsJson()) {
+            return response()->json($quote);
+        }
+
+        return redirect()->route('portal.quotes.show', $quote)
+            ->with('status', 'Quote updated.');
     }
 
     /**
-     * Remove the specified resource from storage.
+     * Remove the specified quote from storage.
      */
-    public function destroy(Quote $quote)
+    public function destroy(Request $request, Quote $quote)
     {
-        //
+        abort_if($quote->user_id !== $request->user()->id, 403);
+
+        $quote->delete();
+
+        if ($request->wantsJson()) {
+            return response()->json([], 204);
+        }
+
+        return redirect()->route('portal.quotes.index')
+            ->with('status', 'Quote deleted.');
     }
 
     public function approve(Request $request, Quote $quote): RedirectResponse

--- a/resources/views/portal/quotes/create.blade.php
+++ b/resources/views/portal/quotes/create.blade.php
@@ -1,0 +1,14 @@
+@extends('layouts.portal')
+
+@section('portal-content')
+<h1 class="text-2xl font-semibold mb-4">New Quote</h1>
+
+<form method="POST" action="{{ route('portal.quotes.store') }}" class="space-y-4">
+    @csrf
+    <div>
+        <label class="block text-sm font-medium text-gray-700">Valid Until</label>
+        <input type="date" name="valid_until" class="mt-1 block w-full border-gray-300 rounded" />
+    </div>
+    <button type="submit" class="px-4 py-2 bg-blue-600 text-white rounded">Save</button>
+</form>
+@endsection

--- a/resources/views/portal/quotes/edit.blade.php
+++ b/resources/views/portal/quotes/edit.blade.php
@@ -1,0 +1,15 @@
+@extends('layouts.portal')
+
+@section('portal-content')
+<h1 class="text-2xl font-semibold mb-4">Edit Quote {{ $quote->number }}</h1>
+
+<form method="POST" action="{{ route('portal.quotes.update', $quote) }}" class="space-y-4">
+    @csrf
+    @method('PUT')
+    <div>
+        <label class="block text-sm font-medium text-gray-700">Valid Until</label>
+        <input type="date" name="valid_until" value="{{ optional($quote->valid_until)->format('Y-m-d') }}" class="mt-1 block w-full border-gray-300 rounded" />
+    </div>
+    <button type="submit" class="px-4 py-2 bg-blue-600 text-white rounded">Update</button>
+</form>
+@endsection

--- a/resources/views/portal/quotes/index.blade.php
+++ b/resources/views/portal/quotes/index.blade.php
@@ -1,0 +1,36 @@
+@extends('layouts.portal')
+
+@section('portal-content')
+<h1 class="text-2xl font-semibold mb-4">Quotes</h1>
+
+<table class="min-w-full bg-white dark:bg-gray-900 rounded shadow">
+    <thead class="bg-gray-100 dark:bg-gray-800 text-left">
+        <tr>
+            <th class="px-4 py-2">Number</th>
+            <th class="px-4 py-2">Status</th>
+            <th class="px-4 py-2">Total</th>
+            <th class="px-4 py-2">Action</th>
+        </tr>
+    </thead>
+    <tbody>
+        @forelse($quotes as $quote)
+            <tr class="border-t border-gray-200 dark:border-gray-700">
+                <td class="px-4 py-2">{{ $quote->number }}</td>
+                <td class="px-4 py-2 capitalize">{{ $quote->status }}</td>
+                <td class="px-4 py-2">{{ $quote->grand_total }}</td>
+                <td class="px-4 py-2">
+                    <a href="{{ route('portal.quotes.show', $quote) }}" class="text-blue-600 hover:underline">View</a>
+                </td>
+            </tr>
+        @empty
+            <tr>
+                <td colspan="4" class="px-4 py-4 text-center text-gray-500">No quotes found.</td>
+            </tr>
+        @endforelse
+    </tbody>
+</table>
+
+<div class="mt-4">
+    {{ $quotes->links() }}
+</div>
+@endsection

--- a/resources/views/portal/quotes/show.blade.php
+++ b/resources/views/portal/quotes/show.blade.php
@@ -1,0 +1,37 @@
+@extends('layouts.portal')
+
+@section('portal-content')
+<h1 class="text-2xl font-semibold mb-4">Quote {{ $quote->number }}</h1>
+
+<div class="mb-4">
+    <p><strong>Status:</strong> <span class="capitalize">{{ $quote->status }}</span></p>
+    <p><strong>Valid Until:</strong> {{ optional($quote->valid_until)->toFormattedDateString() }}</p>
+    <p><strong>Total:</strong> {{ $quote->grand_total }}</p>
+</div>
+
+<h2 class="text-xl font-semibold mb-2">Items</h2>
+<table class="min-w-full bg-white dark:bg-gray-900 rounded shadow">
+    <thead class="bg-gray-100 dark:bg-gray-800 text-left">
+        <tr>
+            <th class="px-4 py-2">Title</th>
+            <th class="px-4 py-2">Qty</th>
+            <th class="px-4 py-2">Unit Price</th>
+            <th class="px-4 py-2">Total</th>
+        </tr>
+    </thead>
+    <tbody>
+        @forelse($quote->items as $item)
+            <tr class="border-t border-gray-200 dark:border-gray-700">
+                <td class="px-4 py-2">{{ $item->title }}</td>
+                <td class="px-4 py-2">{{ $item->qty }}</td>
+                <td class="px-4 py-2">{{ $item->unit_price }}</td>
+                <td class="px-4 py-2">{{ $item->qty * $item->unit_price }}</td>
+            </tr>
+        @empty
+            <tr>
+                <td colspan="4" class="px-4 py-4 text-center text-gray-500">No items.</td>
+            </tr>
+        @endforelse
+    </tbody>
+</table>
+@endsection

--- a/routes/portal.php
+++ b/routes/portal.php
@@ -11,6 +11,7 @@ Route::middleware(['auth', 'verified', 'twofactor'])->group(function () {
         return 'Client Portal';
     });
 
+    Route::resource('quotes', QuoteController::class);
     Route::post('quotes/{quote}/approve', [QuoteController::class, 'approve'])
         ->name('quotes.approve');
     Route::post('quotes/{quote}/reject', [QuoteController::class, 'reject'])


### PR DESCRIPTION
## Summary
- implement full CRUD for portal quotes with per-user authorization
- add Blade views for listing and displaying quotes
- register portal quote routes

## Testing
- `php artisan test` *(fails: require vendor/autoload.php)*
- `composer install` *(fails: lock file missing required packages)*

------
https://chatgpt.com/codex/tasks/task_e_689f890178248332833989a058ae0d5a