### PR TITLE
Implement detailed order totals during product purchase

### DIFF
--- a/app/Models/Order.php
+++ b/app/Models/Order.php
@@ -17,8 +17,17 @@ class Order extends Model
 
     protected $guarded = [];
 
+    /**
+     * @var array<int, string>
+     */
     protected $fillable = [
         'user_id',
+        'status',
+        'number',
+        'subtotal',
+        'tax_total',
+        'discount_total',
+        'grand_total',
     ];
 
     protected $casts = [

--- a/app/Services/FlowService.php
+++ b/app/Services/FlowService.php
@@ -33,10 +33,16 @@ class FlowService
     public function purchaseProduct(User $user, Product $product): License
     {
         return DB::transaction(function () use ($user, $product) {
+            $price = $product->price ?? 0;
+
             $order = Order::create([
                 'user_id' => $user->id,
                 'status' => 'paid',
-                'total' => $product->price ?? 0,
+                'number' => (string) Str::uuid(),
+                'subtotal' => $price,
+                'tax_total' => 0,
+                'discount_total' => 0,
+                'grand_total' => $price,
             ]);
 
             return License::create([

--- a/tests/Feature/PurchaseLicenseUpdateTest.php
+++ b/tests/Feature/PurchaseLicenseUpdateTest.php
@@ -16,6 +16,14 @@ it('issues license on purchase and serves update download', function () {
 
     $license = app(FlowService::class)->purchaseProduct($user, $product);
 
+    $order = $license->order;
+    $expectedPrice = $product->price ?? 0.0;
+    expect($order->number)->not->toBeEmpty();
+    expect($order->subtotal)->toBe($expectedPrice);
+    expect($order->tax_total)->toBe(0.0);
+    expect($order->discount_total)->toBe(0.0);
+    expect($order->grand_total)->toBe($expectedPrice);
+
     $invoice = Invoice::factory()->create(['order_id' => $license->order_id]);
     expect($invoice->order_id)->toBe($license->order_id);
 


### PR DESCRIPTION
## Summary
- Generate unique order numbers and store subtotal, taxes, discounts, and grand total when purchasing a product
- Expose new order attributes on the `Order` model for mass assignment
- Extend purchase flow test to verify order creation data

## Testing
- `php artisan test` *(fails: vendor/autoload.php not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a78eab26e083329f27366f30d3fec2