### PR TITLE
Clean up portal resource routes

### DIFF
--- a/routes/portal.php
+++ b/routes/portal.php
@@ -19,8 +19,6 @@ Route::middleware(['auth', 'verified', 'twofactor'])->group(function () {
     Route::post('quotes/{quote}/reject', [QuoteController::class, 'reject'])
         ->name('quotes.reject');
 
-    Route::resource('quotes', QuoteController::class)->only(['index', 'show']);
-
     Route::resource('projects', ProjectController::class);
     Route::resource('tickets', TicketController::class);
 
@@ -37,8 +35,5 @@ Route::middleware(['auth', 'verified', 'twofactor'])->group(function () {
     Route::get('licenses/{license}/download/{release}', [LicenseController::class, 'download'])
         ->name('licenses.download')
         ->middleware('signed');
-
-    Route::resource('projects', ProjectController::class);
-    Route::resource('tickets', TicketController::class);
 });
 


### PR DESCRIPTION
## Summary
- remove duplicate `Route::resource` calls for quotes, projects, and tickets in portal routes

## Testing
- `php artisan route:list --name=portal.quotes.index`
- `php artisan route:list --name=portal.projects.index`
- `php artisan route:list --name=portal.tickets.index`
- `php artisan test` *(fails: Tests\Feature\StripeWebhookTest > it handles stripe invoice paid webhook)*

------
https://chatgpt.com/codex/tasks/task_e_68a78fa030448332a2e8235e5cac6b42