### PR TITLE
Link tickets to orders and capture initial message

### DIFF
--- a/app/Http/Requests/Portal/TicketRequest.php
+++ b/app/Http/Requests/Portal/TicketRequest.php
@@ -18,6 +18,8 @@ class TicketRequest extends FormRequest
             'category' => ['nullable', 'string', 'max:255'],
             'priority' => ['required', 'in:low,normal,high,urgent'],
             'status' => ['sometimes', 'in:open,pending,resolved,closed'],
+            'body' => ['required', 'string'],
+            'order_id' => ['nullable', 'exists:orders,id'],
         ];
     }
 }

--- a/app/Models/Ticket.php
+++ b/app/Models/Ticket.php
@@ -35,6 +35,11 @@ class Ticket extends Model
         return $this->belongsTo(Project::class);
     }
 
+    public function order()
+    {
+        return $this->belongsTo(Order::class);
+    }
+
     public function replies()
     {
         return $this->hasMany(TicketReply::class);

--- a/database/factories/TicketFactory.php
+++ b/database/factories/TicketFactory.php
@@ -19,11 +19,12 @@ class TicketFactory extends Factory
         return [
             'user_id' => User::factory(),
             'project_id' => Project::factory(),
+            'order_id' => null,
             'subject' => $this->faker->sentence(),
             'category' => $this->faker->word(),
             'priority' => $this->faker->randomElement(['low','normal','high','urgent']),
             'status' => $this->faker->randomElement(['open','pending','resolved','closed']),
-            'project_id' => Project::factory(),
+            'body' => $this->faker->paragraph(),
             'last_activity_at' => now(),
         ];
     }

--- a/database/migrations/2025_08_14_113207_create_perfex_dev_360_tables.php
+++ b/database/migrations/2025_08_14_113207_create_perfex_dev_360_tables.php
@@ -641,10 +641,12 @@ return new class extends Migration {
         Schema::create('tickets', function (Blueprint $table) {
             $table->id();
             $table->foreignId('user_id')->nullable()->constrained()->nullOnDelete(); // client
+            $table->foreignId('order_id')->nullable()->constrained()->nullOnDelete();
             $table->string('subject');
             $table->string('category')->nullable();
             $table->string('priority')->default('normal'); // low, normal, high, urgent
             $table->string('status')->default('open'); // open, pending, resolved, closed
+            $table->text('body');
             $table->timestamp('last_activity_at')->nullable();
             $table->timestamps();
         });
@@ -674,7 +676,7 @@ return new class extends Migration {
                 ->nullable()
                 ->constrained()
                 ->nullOnDelete()
-                ->after('user_id');
+                ->after('order_id');
         });
 
         Schema::create('milestones', function (Blueprint $table) {

--- a/resources/views/portal/tickets/create.blade.php
+++ b/resources/views/portal/tickets/create.blade.php
@@ -1,0 +1,45 @@
+@extends('layouts.portal')
+
+@section('portal-content')
+<div class="p-4">
+    <h1 class="text-2xl font-bold mb-4">Open Ticket</h1>
+
+    <form method="POST" action="{{ route('portal.tickets.store') }}" class="space-y-4">
+        @csrf
+        <div>
+            <label class="block mb-1 font-medium" for="subject">Subject</label>
+            <input id="subject" name="subject" type="text" class="w-full border p-2" required>
+        </div>
+
+        <div>
+            <label class="block mb-1 font-medium" for="order_id">Order</label>
+            <select id="order_id" name="order_id" class="w-full border p-2">
+                <option value="">-- None --</option>
+                @foreach($orders as $order)
+                    <option value="{{ $order->id }}">Order #{{ $order->id }}</option>
+                @endforeach
+            </select>
+        </div>
+
+        <div>
+            <label class="block mb-1 font-medium" for="priority">Priority</label>
+            <select id="priority" name="priority" class="w-full border p-2">
+                <option value="low">Low</option>
+                <option value="normal" selected>Normal</option>
+                <option value="high">High</option>
+                <option value="urgent">Urgent</option>
+            </select>
+        </div>
+
+        <div>
+            <label class="block mb-1 font-medium" for="body">Message</label>
+            <textarea id="body" name="body" rows="6" class="w-full border p-2" required></textarea>
+        </div>
+
+        <div>
+            <button type="submit" class="px-4 py-2 bg-blue-600 text-white rounded">Submit</button>
+        </div>
+    </form>
+</div>
+@endsection
+

--- a/resources/views/portal/tickets/edit.blade.php
+++ b/resources/views/portal/tickets/edit.blade.php
@@ -3,5 +3,43 @@
 @section('portal-content')
 <div class="p-4">
     <h1 class="text-2xl font-bold mb-4">Edit Ticket</h1>
+
+    <form method="POST" action="{{ route('portal.tickets.update', $ticket) }}" class="space-y-4">
+        @csrf
+        @method('PUT')
+
+        <div>
+            <label class="block mb-1 font-medium" for="subject">Subject</label>
+            <input id="subject" name="subject" type="text" class="w-full border p-2" value="{{ $ticket->subject }}" required>
+        </div>
+
+        <div>
+            <label class="block mb-1 font-medium" for="order_id">Order</label>
+            <select id="order_id" name="order_id" class="w-full border p-2">
+                <option value="">-- None --</option>
+                @foreach($orders as $order)
+                    <option value="{{ $order->id }}" @selected($ticket->order_id === $order->id)>Order #{{ $order->id }}</option>
+                @endforeach
+            </select>
+        </div>
+
+        <div>
+            <label class="block mb-1 font-medium" for="priority">Priority</label>
+            <select id="priority" name="priority" class="w-full border p-2">
+                @foreach(['low','normal','high','urgent'] as $level)
+                    <option value="{{ $level }}" @selected($ticket->priority === $level)>{{ ucfirst($level) }}</option>
+                @endforeach
+            </select>
+        </div>
+
+        <div>
+            <label class="block mb-1 font-medium" for="body">Message</label>
+            <textarea id="body" name="body" rows="6" class="w-full border p-2" required>{{ $ticket->body }}</textarea>
+        </div>
+
+        <div>
+            <button type="submit" class="px-4 py-2 bg-blue-600 text-white rounded">Update</button>
+        </div>
+    </form>
 </div>
 @endsection

--- a/resources/views/portal/tickets/index.blade.php
+++ b/resources/views/portal/tickets/index.blade.php
@@ -1,0 +1,33 @@
+@extends('layouts.portal')
+
+@section('portal-content')
+<div class="p-4">
+    <h1 class="text-2xl font-bold mb-4">Tickets</h1>
+
+    <table class="min-w-full border">
+        <thead>
+            <tr class="bg-gray-50">
+                <th class="px-4 py-2 text-left">Subject</th>
+                <th class="px-4 py-2 text-left">Order</th>
+            </tr>
+        </thead>
+        <tbody>
+            @forelse($tickets as $ticket)
+                <tr class="border-t">
+                    <td class="px-4 py-2">
+                        <a href="{{ route('portal.tickets.show', $ticket) }}" class="text-blue-600">{{ $ticket->subject }}</a>
+                    </td>
+                    <td class="px-4 py-2">
+                        {{ $ticket->order_id ? 'Order #' . $ticket->order_id : '-' }}
+                    </td>
+                </tr>
+            @empty
+                <tr>
+                    <td colspan="2" class="px-4 py-2 text-center text-gray-500">No tickets found.</td>
+                </tr>
+            @endforelse
+        </tbody>
+    </table>
+</div>
+@endsection
+

--- a/resources/views/portal/tickets/show.blade.php
+++ b/resources/views/portal/tickets/show.blade.php
@@ -1,0 +1,28 @@
+@extends('layouts.portal')
+
+@section('portal-content')
+<div class="p-4 space-y-4">
+    <h1 class="text-2xl font-bold">{{ $ticket->subject }}</h1>
+
+    @if($ticket->order_id)
+        <div>Order #{{ $ticket->order_id }}</div>
+    @endif
+
+    <div class="prose">
+        {{ $ticket->body }}
+    </div>
+
+    <div class="mt-6">
+        <h2 class="font-semibold mb-2">Replies</h2>
+        <div class="space-y-4">
+            @foreach($ticket->replies as $reply)
+                <div class="border p-2">
+                    <p class="mb-1 text-sm text-gray-600">{{ $reply->created_at->format('Y-m-d H:i') }}</p>
+                    <p>{{ $reply->body }}</p>
+                </div>
+            @endforeach
+        </div>
+    </div>
+</div>
+@endsection
+

--- a/tests/Feature/TicketNotificationTest.php
+++ b/tests/Feature/TicketNotificationTest.php
@@ -13,6 +13,7 @@ it('sends email when ticket is created', function () {
     Ticket::create([
         'user_id' => $user->id,
         'subject' => 'Support needed',
+        'body' => 'Initial message',
     ]);
 
     Notification::assertSentOnDemand(TicketCreated::class);

--- a/tests/Feature/TicketOrderTest.php
+++ b/tests/Feature/TicketOrderTest.php
@@ -1,0 +1,34 @@
+<?php
+
+use App\Models\Order;
+use App\Models\Ticket;
+use App\Models\User;
+use App\Http\Controllers\Portal\TicketController;
+use App\Http\Requests\Portal\TicketRequest;
+use Illuminate\Support\Str;
+
+it('opens a ticket for an order and stores the message', function () {
+    $user = User::factory()->create();
+    $order = Order::factory()->create(['user_id' => $user->id]);
+    config(['app.key' => Str::random(32)]);
+
+    $request = TicketRequest::create('/portal/tickets', 'POST', [
+        'subject' => 'Order issue',
+        'priority' => 'normal',
+        'body' => 'Need help with order',
+        'order_id' => $order->id,
+    ]);
+    $request->setUserResolver(fn () => $user);
+    $request->setContainer(app());
+    $request->validateResolved();
+
+    $controller = app(TicketController::class);
+    $controller->store($request);
+
+    $ticket = Ticket::first();
+
+    expect($ticket->order_id)->toBe($order->id);
+    expect($ticket->body)->toBe('Need help with order');
+    expect($ticket->replies()->first()->body)->toBe('Need help with order');
+});
+


### PR DESCRIPTION
## Summary
- Allow tickets to reference orders and store an initial message
- Validate ticket body and order association
- Add UI and tests for opening tickets with order context

## Testing
- `php artisan test` *(fails: MissingApiKey, auth middleware, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a79100c4f883328984ef7d3f302f8d