### PR TITLE
Add order item relationships and tests

### DIFF
--- a/app/Models/Order.php
+++ b/app/Models/Order.php
@@ -10,6 +10,8 @@ use Illuminate\Database\Eloquent\Relations\HasOne;
 use App\Models\User;
 use App\Models\License;
 use App\Models\Invoice;
+use App\Models\OrderItem;
+use App\Models\TaxLine;
 
 class Order extends Model
 {
@@ -45,6 +47,16 @@ class Order extends Model
     public function invoices(): HasMany
     {
         return $this->hasMany(Invoice::class);
+    }
+
+    public function items(): HasMany
+    {
+        return $this->hasMany(OrderItem::class);
+    }
+
+    public function taxLines(): HasMany
+    {
+        return $this->hasMany(TaxLine::class);
     }
 
     /**

--- a/app/Models/OrderItem.php
+++ b/app/Models/OrderItem.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class OrderItem extends Model
 {
@@ -11,7 +12,32 @@ class OrderItem extends Model
 
     protected $guarded = [];
 
+    /**
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        'order_id',
+        'product_id',
+        'edition_id',
+        'qty',
+        'unit_price',
+        'tax_amount',
+        'discount_amount',
+        'total',
+        'meta',
+    ];
+
     protected $casts = [
         'meta' => 'array',
     ];
+
+    public function order(): BelongsTo
+    {
+        return $this->belongsTo(Order::class);
+    }
+
+    public function product(): BelongsTo
+    {
+        return $this->belongsTo(Product::class);
+    }
 }

--- a/tests/Unit/OrderRelationshipsTest.php
+++ b/tests/Unit/OrderRelationshipsTest.php
@@ -1,0 +1,54 @@
+<?php
+
+use App\Models\Order;
+use App\Models\OrderItem;
+use App\Models\Product;
+use App\Models\TaxLine;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(Tests\TestCase::class, RefreshDatabase::class);
+
+it('associates items and tax lines with an order', function () {
+    $order = Order::factory()->create();
+    $product = Product::factory()->create();
+
+    $item = OrderItem::create([
+        'order_id' => $order->id,
+        'product_id' => $product->id,
+        'qty' => 1,
+        'unit_price' => 100,
+        'tax_amount' => 10,
+        'discount_amount' => 0,
+        'total' => 110,
+    ]);
+
+    $taxLine = new TaxLine();
+    $taxLine->order_id = $order->id;
+    $taxLine->name = 'VAT';
+    $taxLine->amount = 10;
+    $taxLine->save();
+
+    expect($order->items)->toHaveCount(1)
+        ->and($order->items->first()->is($item))->toBeTrue()
+        ->and($order->taxLines)->toHaveCount(1)
+        ->and($order->taxLines->first()->is($taxLine))->toBeTrue();
+});
+
+it('order item belongs to order and product', function () {
+    $order = Order::factory()->create();
+    $product = Product::factory()->create();
+
+    $item = OrderItem::create([
+        'order_id' => $order->id,
+        'product_id' => $product->id,
+        'qty' => 2,
+        'unit_price' => 50,
+        'tax_amount' => 0,
+        'discount_amount' => 0,
+        'total' => 100,
+    ]);
+
+    expect($item->order->is($order))->toBeTrue()
+        ->and($item->product->is($product))->toBeTrue();
+});
+


### PR DESCRIPTION
## Summary
- link orders to their line items and tax lines
- expose order and product relations on OrderItem
- test order-item and tax-line associations

## Testing
- `./vendor/bin/pest tests/Unit/OrderRelationshipsTest.php`
- `composer test` *(fails: MissingApiKey and other existing test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68a7940795d88332b52249c87a66685f