### PR TITLE
Add order review feature

### DIFF
--- a/app/Http/Controllers/Api/OrderReviewController.php
+++ b/app/Http/Controllers/Api/OrderReviewController.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\Order;
+use App\Models\OrderReview;
+use Illuminate\Http\Request;
+
+class OrderReviewController extends Controller
+{
+    public function store(Request $request, Order $order)
+    {
+        $data = $request->validate([
+            'rating' => ['required', 'integer', 'min:1', 'max:5'],
+            'comment' => ['nullable', 'string'],
+        ]);
+
+        abort_unless($order->status === 'paid' && $order->user_id === $request->user()->id, 403);
+
+        $review = OrderReview::updateOrCreate(
+            ['order_id' => $order->id, 'user_id' => $request->user()->id],
+            $data
+        );
+
+        return response()->json($review, 201);
+    }
+
+    public function update(Request $request, Order $order)
+    {
+        $data = $request->validate([
+            'rating' => ['required', 'integer', 'min:1', 'max:5'],
+            'comment' => ['nullable', 'string'],
+        ]);
+
+        abort_unless($order->status === 'paid' && $order->user_id === $request->user()->id, 403);
+
+        $review = $order->reviews()->where('user_id', $request->user()->id)->firstOrFail();
+        $review->update($data);
+
+        return response()->json($review);
+    }
+}

--- a/app/Http/Controllers/Portal/OrderReviewController.php
+++ b/app/Http/Controllers/Portal/OrderReviewController.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Http\Controllers\Portal;
+
+use App\Http\Controllers\Controller;
+use App\Models\Order;
+use App\Models\OrderReview;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class OrderReviewController extends Controller
+{
+    public function store(Request $request, Order $order): RedirectResponse
+    {
+        $data = $request->validate([
+            'rating' => ['required', 'integer', 'min:1', 'max:5'],
+            'comment' => ['nullable', 'string'],
+        ]);
+
+        abort_unless($order->status === 'paid' && $order->user_id === Auth::id(), 403);
+
+        OrderReview::updateOrCreate(
+            ['order_id' => $order->id, 'user_id' => Auth::id()],
+            $data
+        );
+
+        return back()->with('status', 'Review submitted');
+    }
+
+    public function update(Request $request, Order $order): RedirectResponse
+    {
+        $data = $request->validate([
+            'rating' => ['required', 'integer', 'min:1', 'max:5'],
+            'comment' => ['nullable', 'string'],
+        ]);
+
+        abort_unless($order->status === 'paid' && $order->user_id === Auth::id(), 403);
+
+        $review = $order->reviews()->where('user_id', Auth::id())->firstOrFail();
+        $review->update($data);
+
+        return back()->with('status', 'Review updated');
+    }
+}

--- a/app/Models/Order.php
+++ b/app/Models/Order.php
@@ -12,6 +12,7 @@ use App\Models\License;
 use App\Models\Invoice;
 use App\Models\OrderItem;
 use App\Models\TaxLine;
+use App\Models\OrderReview;
 
 class Order extends Model
 {
@@ -65,5 +66,15 @@ class Order extends Model
     public function license(): HasOne
     {
         return $this->hasOne(License::class);
+    }
+
+    public function reviews(): HasMany
+    {
+        return $this->hasMany(OrderReview::class);
+    }
+
+    public function getAverageRatingAttribute(): ?float
+    {
+        return $this->reviews()->avg('rating');
     }
 }

--- a/app/Models/OrderReview.php
+++ b/app/Models/OrderReview.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class OrderReview extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'order_id',
+        'user_id',
+        'rating',
+        'comment',
+    ];
+
+    public function order(): BelongsTo
+    {
+        return $this->belongsTo(Order::class);
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/database/factories/OrderReviewFactory.php
+++ b/database/factories/OrderReviewFactory.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\OrderReview;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<OrderReview>
+ */
+class OrderReviewFactory extends Factory
+{
+    protected $model = OrderReview::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'rating' => $this->faker->numberBetween(1, 5),
+            'comment' => $this->faker->sentence(),
+        ];
+    }
+}

--- a/database/migrations/2025_08_21_221604_create_order_reviews_table.php
+++ b/database/migrations/2025_08_21_221604_create_order_reviews_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('order_reviews', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('order_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->unsignedTinyInteger('rating');
+            $table->text('comment')->nullable();
+            $table->timestamps();
+            $table->unique(['order_id', 'user_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('order_reviews');
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -2,7 +2,7 @@
 
 namespace Database\Seeders;
 
-use App\Models\{BlogPost, Invoice, Lead, License, Order, Page, PipelineStage, Product, Project, Quote, ReleaseChannel, Ticket, User, Version, Setting};
+use App\Models\{BlogPost, Invoice, Lead, License, Order, OrderReview, Page, PipelineStage, Product, Project, Quote, ReleaseChannel, Ticket, User, Version, Setting};
 use Illuminate\Database\Seeder;
 
 class DatabaseSeeder extends Seeder
@@ -54,7 +54,10 @@ class DatabaseSeeder extends Seeder
             ->count(5)
             ->for($users->random())
             ->has(Invoice::factory())
-            ->create();
+            ->create()
+            ->each(function ($order) {
+                OrderReview::factory()->for($order)->for($order->user)->create();
+            });
 
         Project::factory()
             ->count(3)

--- a/resources/views/portal/purchases/show.blade.php
+++ b/resources/views/portal/purchases/show.blade.php
@@ -22,5 +22,33 @@
             @endforelse
         </ul>
     </div>
+
+    @if($order->status === 'paid')
+        <div>
+            <h2 class="text-xl font-semibold mb-2">Your Review</h2>
+            @php($review = $order->reviews->firstWhere('user_id', auth()->id()))
+            <form method="POST" action="{{ $review ? route('portal.purchases.review.update', $order) : route('portal.purchases.review.store', $order) }}" class="space-y-4">
+                @csrf
+                @if($review)
+                    @method('PUT')
+                @endif
+                <div>
+                    <label class="block mb-1">Rating</label>
+                    <select name="rating" class="border rounded p-2">
+                        @for($i = 1; $i <= 5; $i++)
+                            <option value="{{ $i }}" @selected(old('rating', $review->rating ?? '') == $i)>{{ $i }}</option>
+                        @endfor
+                    </select>
+                </div>
+                <div>
+                    <label class="block mb-1">Comment</label>
+                    <textarea name="comment" class="border rounded w-full p-2">{{ old('comment', $review->comment ?? '') }}</textarea>
+                </div>
+                <button class="px-4 py-2 bg-blue-600 text-white rounded">
+                    {{ $review ? 'Update Review' : 'Submit Review' }}
+                </button>
+            </form>
+        </div>
+    @endif
 </div>
 @endsection

--- a/routes/api.php
+++ b/routes/api.php
@@ -5,7 +5,14 @@ use App\Http\Controllers\Api\ActivationController;
 use App\Http\Controllers\Api\DownloadController;
 use App\Http\Controllers\Api\RotationController;
 use App\Http\Controllers\Api\UpdateController;
+use App\Http\Controllers\Api\OrderReviewController;
+
 Route::middleware('throttle:10,1')->post('/licenses/activate', ActivationController::class);
 Route::middleware('throttle:10,1')->post('/licenses/rotate', RotationController::class);
 Route::middleware('throttle:10,1')->get('/updates', UpdateController::class);
 Route::middleware('throttle:10,1')->get('/download/{release}', DownloadController::class)->name('releases.download');
+
+Route::middleware('auth')->group(function () {
+    Route::post('/orders/{order}/review', [OrderReviewController::class, 'store']);
+    Route::put('/orders/{order}/review', [OrderReviewController::class, 'update']);
+});

--- a/routes/portal.php
+++ b/routes/portal.php
@@ -7,6 +7,7 @@ use App\Http\Controllers\Portal\QuoteController;
 use App\Http\Controllers\Portal\InvoiceController;
 use App\Http\Controllers\Portal\ProjectController;
 use App\Http\Controllers\Portal\TicketController;
+use App\Http\Controllers\Portal\OrderReviewController;
 
 Route::middleware(['auth', 'verified', 'twofactor'])->group(function () {
     Route::get('/', function () {
@@ -29,6 +30,10 @@ Route::middleware(['auth', 'verified', 'twofactor'])->group(function () {
         ->name('invoices.receipt');
 
     Route::resource('purchases', PurchaseController::class)->only(['index', 'show']);
+    Route::post('purchases/{order}/review', [OrderReviewController::class, 'store'])
+        ->name('purchases.review.store');
+    Route::put('purchases/{order}/review', [OrderReviewController::class, 'update'])
+        ->name('purchases.review.update');
     Route::resource('licenses', LicenseController::class)->only(['index', 'show']);
     Route::post('licenses/{license}/rotate', [LicenseController::class, 'rotate'])
         ->name('licenses.rotate');

--- a/tests/Feature/OrderReviewTest.php
+++ b/tests/Feature/OrderReviewTest.php
@@ -1,0 +1,47 @@
+<?php
+
+use App\Models\Order;
+use App\Models\OrderReview;
+use App\Models\User;
+use function Pest\Laravel\actingAs;
+
+it('allows authenticated users to submit a review', function () {
+    $user = User::factory()->create();
+    $order = Order::factory()->for($user)->create(['status' => 'paid']);
+
+    actingAs($user);
+
+    $this->postJson('/api/v1/orders/'.$order->id.'/review', [
+        'rating' => 5,
+        'comment' => 'Great!',
+    ])->assertCreated();
+
+    $this->assertDatabaseHas('order_reviews', [
+        'order_id' => $order->id,
+        'user_id' => $user->id,
+        'rating' => 5,
+    ]);
+
+    expect($order->fresh()->average_rating)->toBe(5.0);
+});
+
+it('allows users to update their review', function () {
+    $user = User::factory()->create();
+    $order = Order::factory()->for($user)->create(['status' => 'paid']);
+    $review = OrderReview::factory()->for($order)->for($user)->create(['rating' => 4]);
+
+    actingAs($user);
+
+    $this->putJson('/api/v1/orders/'.$order->id.'/review', [
+        'rating' => 3,
+        'comment' => 'Okay',
+    ])->assertOk();
+
+    $this->assertDatabaseHas('order_reviews', [
+        'id' => $review->id,
+        'rating' => 3,
+        'comment' => 'Okay',
+    ]);
+
+    expect($order->fresh()->average_rating)->toBe(3.0);
+});


### PR DESCRIPTION
## Summary
- allow customers to review orders and update ratings
- expose review submission via portal and API endpoints
- seed demo order reviews and cover with feature tests

## Testing
- `composer test` *(fails: Missing Gemini API Key and other configuration)*
- `php artisan test tests/Feature/OrderReviewTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68a799b81a3c83328149369156415b22